### PR TITLE
Chore: .gitignore 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,54 @@ out/
 
 ### VS Code ###
 .vscode/
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Gradle template
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# dev config files
+src/main/resources/application-dev.yml


### PR DESCRIPTION
- IDE 및 빌드 관련 파일 제외
- Gradle, Java, Spring 관련 불필요한 파일 무시
- 환경별 설정 파일(application-dev.yml) 관리 고려