### PR TITLE
[Refactor] Map Song 관련 전반적인 CRUD 리펙토링

### DIFF
--- a/src/main/java/com/lshzzz/mato/controller/MapController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapController.java
@@ -4,10 +4,14 @@ import com.lshzzz.mato.model.map.dto.MapRequestDto;
 import com.lshzzz.mato.model.map.dto.MapResponseDto;
 import com.lshzzz.mato.service.MapService;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/maps")
@@ -19,6 +23,13 @@ public class MapController {
 	@PostMapping
 	public ResponseEntity<MapResponseDto> createMap(@RequestBody MapRequestDto requestDto) {
 		return ResponseEntity.ok(mapService.createMap(requestDto));
+	}
+
+	// 🔹 맵 이름 중복 체크 (예외 던지지 않고 바로 응답)
+	@GetMapping("/check")
+	public ResponseEntity<Map<String, Boolean>> checkMapExists(@RequestParam String name) {
+		boolean exists = mapService.checkDuplicateMap(name);
+		return ResponseEntity.ok(Collections.singletonMap("isDuplicate", exists));
 	}
 
 	// 🔹 특정 맵 조회
@@ -39,10 +50,10 @@ public class MapController {
 		return ResponseEntity.ok(mapService.updateMap(id, requestDto));
 	}
 
-	// 🔹 맵 삭제
+	// 🔹 맵 삭제 (❗ `@RequestBody` 대신 `@RequestParam` 사용)
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteMap(@PathVariable Long id, @RequestBody MapRequestDto requestDto) {
-		mapService.deleteMap(id, requestDto.userId());
+	public ResponseEntity<Void> deleteMap(@PathVariable Long id, @RequestParam Long userId) {
+		mapService.deleteMap(id, userId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/lshzzz/mato/controller/MapController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapController.java
@@ -4,55 +4,66 @@ import com.lshzzz.mato.model.map.dto.MapRequestDto;
 import com.lshzzz.mato.model.map.dto.MapResponseDto;
 import com.lshzzz.mato.service.MapService;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
+
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @RestController
-@RequestMapping("/api/maps")
 @RequiredArgsConstructor
+@RequestMapping("/api/maps")
 public class MapController {
 	private final MapService mapService;
 
-	// 🔹 맵 생성
+	// 새로운 맵 생성 (옵션: 노래 목록도 함께 추가 가능)
 	@PostMapping
-	public ResponseEntity<MapResponseDto> createMap(@RequestBody MapRequestDto requestDto) {
-		return ResponseEntity.ok(mapService.createMap(requestDto));
+	public ResponseEntity<MapResponseDto> createMap(@RequestBody @Valid MapRequestDto requestDto) {
+		// 요청 DTO에는 맵 정보와 추가할 노래 목록(기존 또는 새로운 노래)이 포함됨
+		MapResponseDto createdMap = mapService.createMap(requestDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(createdMap);
 	}
 
-	// 🔹 맵 이름 중복 체크 (예외 던지지 않고 바로 응답)
 	@GetMapping("/check")
-	public ResponseEntity<Map<String, Boolean>> checkMapExists(@RequestParam String name) {
-		boolean exists = mapService.checkDuplicateMap(name);
-		return ResponseEntity.ok(Collections.singletonMap("isDuplicate", exists));
+	public ResponseEntity<?> checkMapExists(@RequestParam String name) {
+		try {
+			boolean exists = mapService.checkDuplicateMap(name);
+			return ResponseEntity.ok(Collections.singletonMap("isDuplicate", exists));
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(Collections.singletonMap("error", "중복 검사 중 오류 발생"));
+		}
 	}
 
-	// 🔹 특정 맵 조회
+	// 특정 맵 정보 조회 (ID 기반)
 	@GetMapping("/{id}")
 	public ResponseEntity<MapResponseDto> getMap(@PathVariable Long id) {
-		return ResponseEntity.ok(mapService.getMapById(id));
+		MapResponseDto map = mapService.getMapById(id);
+		return ResponseEntity.ok(map);
 	}
 
-	// 🔹 공개된 맵 목록 조회
+	// 모든 공개된 맵 조회 (isPublic=true인 맵만 반환)
 	@GetMapping("/public")
 	public ResponseEntity<List<MapResponseDto>> getPublicMaps() {
-		return ResponseEntity.ok(mapService.getPublicMaps());
+		List<MapResponseDto> publicMaps = mapService.getPublicMaps();
+		return ResponseEntity.ok(publicMaps);
 	}
 
-	// 🔹 맵 수정
+	// 맵 정보 수정
 	@PutMapping("/{id}")
-	public ResponseEntity<MapResponseDto> updateMap(@PathVariable Long id, @RequestBody MapRequestDto requestDto) {
-		return ResponseEntity.ok(mapService.updateMap(id, requestDto));
+	public ResponseEntity<MapResponseDto> updateMap(@PathVariable Long id,
+		@RequestBody @Valid MapRequestDto requestDto) {
+		MapResponseDto updatedMap = mapService.updateMap(id, requestDto);
+		return ResponseEntity.ok(updatedMap);
 	}
 
-	// 🔹 맵 삭제 (❗ `@RequestBody` 대신 `@RequestParam` 사용)
+	// 맵 삭제 (삭제 권한 검사를 위해 userId를 요청 파라미터로 전달)
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteMap(@PathVariable Long id, @RequestParam Long userId) {
+	public ResponseEntity<Void> deleteMap(@PathVariable Long id,
+		@RequestParam Long userId) {
 		mapService.deleteMap(id, userId);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/lshzzz/mato/controller/MapSongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapSongController.java
@@ -3,37 +3,37 @@ package com.lshzzz.mato.controller;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
 import com.lshzzz.mato.service.MapSongService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/mapsongs")
 @RequiredArgsConstructor
+@RequestMapping("/api/maps")
 public class MapSongController {
-
 	private final MapSongService mapSongService;
 
-	// 맵에 노래 추가
+	// 특정 맵에 노래 추가 (기존 노래 또는 새로운 노래 등록 가능)
 	@PostMapping("/{mapId}/songs")
-	public ResponseEntity<MapSongResponseDto> addSongToMap(
-		@PathVariable Long mapId,
-		@Valid @RequestBody MapSongRequestDto requestDto
-	) {
-		return ResponseEntity.ok(mapSongService.addSongToMap(mapId, requestDto));
+	public ResponseEntity<MapSongResponseDto> addSongToMap(@PathVariable Long mapId,
+		@RequestBody @Valid MapSongRequestDto requestDto) {
+		MapSongResponseDto added = mapSongService.addSongToMap(mapId, requestDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(added);
 	}
 
-	// 특정 맵의 노래 목록 조회
-	@GetMapping("/map/{mapId}")
-	public ResponseEntity<List<MapSongResponseDto>> getSongsByMapId(@PathVariable Long mapId) {
-		return ResponseEntity.ok(mapSongService.getSongsByMapId(mapId));
+	// 특정 맵에 연결된 모든 노래 조회
+	@GetMapping("/{mapId}/songs")
+	public ResponseEntity<List<MapSongResponseDto>> getSongsByMap(@PathVariable Long mapId) {
+		List<MapSongResponseDto> songs = mapSongService.getSongsByMapId(mapId);
+		return ResponseEntity.ok(songs);
 	}
 
-	// 맵에서 특정 노래 삭제
-	@DeleteMapping("/{mapSongId}")
+	// 특정 맵에서 노래 제거 (MapSong ID 기준으로 삭제)
+	@DeleteMapping("/songs/{mapSongId}")
 	public ResponseEntity<Void> removeSongFromMap(@PathVariable Long mapSongId) {
 		mapSongService.removeSongFromMap(mapSongId);
 		return ResponseEntity.noContent().build();

--- a/src/main/java/com/lshzzz/mato/controller/SongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/SongController.java
@@ -3,46 +3,52 @@ package com.lshzzz.mato.controller;
 import com.lshzzz.mato.model.song.dto.SongRequestDto;
 import com.lshzzz.mato.model.song.dto.SongResponseDto;
 import com.lshzzz.mato.service.SongService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/songs")
 @RequiredArgsConstructor
+@RequestMapping("/api/songs")
 public class SongController {
-
 	private final SongService songService;
 
-	// 노래 등록
+	// 새로운 노래 생성
 	@PostMapping
-	public ResponseEntity<SongResponseDto> createSong(@Valid @RequestBody SongRequestDto requestDto) {
-		return ResponseEntity.ok(songService.createSong(requestDto));
+	public ResponseEntity<SongResponseDto> createSong(@RequestBody @Valid SongRequestDto requestDto) {
+		SongResponseDto createdSong = songService.createSong(requestDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(createdSong);
 	}
 
 	// 모든 노래 조회
 	@GetMapping
 	public ResponseEntity<List<SongResponseDto>> getAllSongs() {
-		return ResponseEntity.ok(songService.getAllSongs());
+		List<SongResponseDto> songs = songService.getAllSongs();
+		return ResponseEntity.ok(songs);
 	}
 
-	// 특정 노래 조회
+	// 특정 노래 조회 (ID 기준)
 	@GetMapping("/{id}")
-	public ResponseEntity<Optional<SongResponseDto>> getSong(@PathVariable Long id) {
-		return ResponseEntity.ok(songService.getSong(id));
+	public ResponseEntity<SongResponseDto> getSong(@PathVariable Long id) {
+		Optional<SongResponseDto> song = songService.getSong(id);
+		return song.map(ResponseEntity::ok)
+			.orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
 	}
 
-	// 노래 수정
+	// 기존 노래 정보 수정
 	@PutMapping("/{id}")
-	public ResponseEntity<SongResponseDto> updateSong(@PathVariable Long id, @Valid @RequestBody SongRequestDto requestDto) {
-		return ResponseEntity.ok(songService.updateSong(id, requestDto));
+	public ResponseEntity<SongResponseDto> updateSong(@PathVariable Long id,
+		@RequestBody @Valid SongRequestDto requestDto) {
+		SongResponseDto updatedSong = songService.updateSong(id, requestDto);
+		return ResponseEntity.ok(updatedSong);
 	}
 
-	// 노래 삭제
+	// 노래 삭제 (ID 기준)
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> deleteSong(@PathVariable Long id) {
 		songService.deleteSong(id);

--- a/src/main/java/com/lshzzz/mato/model/map/Map.java
+++ b/src/main/java/com/lshzzz/mato/model/map/Map.java
@@ -44,16 +44,6 @@ public class Map extends BaseEntity {
 	@Column(name = "map_status", nullable = false)
 	private Boolean isPublic;
 
-	// Map-Song 연결 (양방향 관계)
-	@OneToMany(mappedBy = "map", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<MapSong> mapSongs = new ArrayList<>();
-
-	// 편의 메서드 (노래 추가)
-	public void addMapSong(MapSong mapSong) {
-		mapSongs.add(mapSong);
-		mapSong.setMaps(this);
-	}
-
 	public void update(String name, String description, Boolean isPublic) {
 		this.name = name;
 		this.description = description;

--- a/src/main/java/com/lshzzz/mato/model/map/dto/MapRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/map/dto/MapRequestDto.java
@@ -1,10 +1,16 @@
 package com.lshzzz.mato.model.map.dto;
 
+import java.util.List;
+
+import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
+
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record MapRequestDto(
 	@NotNull Long userId,
 	@NotNull String name,
 	String description,
-	@NotNull Boolean isPublic
+	@NotNull Boolean isPublic,
+	@Valid List<MapSongRequestDto> songs  // List of songs to add to the map (can be existing or new)
 ) {}

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
@@ -31,11 +31,11 @@ public class MapSong extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "map_id")
+	@JoinColumn(name = "map_id", nullable = false)
 	private Map map;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "song_id")
+	@JoinColumn(name = "song_id", nullable = false)
 	private Song song;
 
 	@Column(nullable = false)
@@ -47,12 +47,4 @@ public class MapSong extends BaseEntity {
 	@Column(nullable = false)
 	private Integer repeatCount; // 반복 횟수
 
-	// 연관관계 편의 메서드
-	public void setMaps(Map map) {
-		this.map = map;
-	}
-
-	public void setSongs(Song song) {
-		this.song = song;
-	}
 }

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongRequestDto.java
@@ -1,10 +1,14 @@
 package com.lshzzz.mato.model.mapsongs.dto;
 
+import com.lshzzz.mato.model.song.dto.SongRequestDto;
+
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record MapSongRequestDto(
-	@NotNull Long songId,     // 노래 ID
+	Long songId,     // 노래 ID
+	@Valid SongRequestDto newSong, // 새로운 노래 정보 (신규 노래 추가 시 사용, songId는 null로)
 	@Min(0) Integer startTime, // 시작 시점 (초 단위)
 	@Min(1) Integer endTime,   // 종료 시점 (초 단위)
 	@Min(1) Integer repeatCount // 반복 횟수 (최소 1번)

--- a/src/main/java/com/lshzzz/mato/model/song/Song.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Song.java
@@ -32,20 +32,6 @@ public class Song extends BaseEntity {
 	@Column(nullable = false)
 	private String youtubeUrl; // 오디오 파일 URL (유튜브 OR 직접 업로드)
 
-	// Map과 연결 (양방향 관계)
-	@OneToMany(mappedBy = "song", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<MapSong> mapSongs = new ArrayList<>();
-
-	// 생성 메서드
-	public static Song create(String title, String artist, String composer, String audioUrl) {
-		return Song.builder()
-			.title(title)
-			.artist(artist)
-			.composer(composer)
-			.youtubeUrl(audioUrl)
-			.build();
-	}
-
 	// 업데이트 메서드
 	public void update(String title, String artist, String composer, String audioUrl) {
 		this.title = title;

--- a/src/main/java/com/lshzzz/mato/repository/MapRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/MapRepository.java
@@ -11,4 +11,6 @@ import com.lshzzz.mato.model.map.Map;
 public interface MapRepository extends JpaRepository<Map, Long> {
 	List<Map> findByIsPublicTrue(); // 공개 맵 목록 조회
 
+	boolean existsByName(String name);
+
 }

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -18,6 +18,11 @@ public class MapService {
 	// 맵 생성
 	@Transactional
 	public MapResponseDto createMap(MapRequestDto requestDto) {
+
+		if (mapRepository.existsByName(requestDto.name().trim())) {
+			throw new IllegalArgumentException("이미 존재하는 맵 이름입니다.");
+		}
+
 		Map map = Map.builder()
 			.userId(requestDto.userId())
 			.name(requestDto.name())

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -3,6 +3,9 @@ package com.lshzzz.mato.service;
 import com.lshzzz.mato.model.map.Map;
 import com.lshzzz.mato.model.map.dto.MapRequestDto;
 import com.lshzzz.mato.model.map.dto.MapResponseDto;
+import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
+import com.lshzzz.mato.model.song.dto.SongRequestDto;
+import com.lshzzz.mato.model.song.dto.SongResponseDto;
 import com.lshzzz.mato.repository.MapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,21 +17,50 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MapService {
 	private final MapRepository mapRepository;
+	private final SongService songService;
+	private final MapSongService mapSongService;
 
 	// 맵 생성
 	@Transactional
 	public MapResponseDto createMap(MapRequestDto requestDto) {
-
+		// 1. 맵(Map) 엔티티 생성 및 저장
 		Map map = Map.builder()
-			.userId(requestDto.userId())
-			.name(requestDto.name())
-			.description(requestDto.description())
-			.isPublic(requestDto.isPublic())
+			.userId(requestDto.userId()) // 사용자 ID 설정
+			.name(requestDto.name()) // 맵 이름 설정
+			.description(requestDto.description()) // 맵 설명 설정
+			.isPublic(requestDto.isPublic()) // 공개 여부 설정
 			.build();
 
-		Map savedMap = mapRepository.save(map);
-		return new MapResponseDto(savedMap);
+		Map savedMap = mapRepository.save(map); // 맵 저장
+
+		// 2. 노래 목록이 제공된 경우, 각 노래를 맵에 추가
+		List<MapSongRequestDto> songsToAdd = requestDto.songs();
+		if (songsToAdd != null) {
+			for (MapSongRequestDto songReq : songsToAdd) {
+				if (songReq.songId() != null) {
+					// 기존에 존재하는 노래일 경우: 맵과 연결만 수행
+					mapSongService.addSongToMap(savedMap.getId(), songReq);
+				} else if (songReq.newSong() != null) {
+					// 새로운 노래일 경우: 먼저 생성한 후 맵과 연결
+					SongRequestDto newSongInfo = songReq.newSong();
+					SongResponseDto createdSong = songService.createSong(newSongInfo);
+
+					// 생성된 노래의 ID를 가져와서 맵에 추가
+					Long newSongId = createdSong.id();
+					MapSongRequestDto linkDto = new MapSongRequestDto(
+						newSongId,
+						null,  // 이미 생성된 노래이므로 SongRequestDto 불필요
+						songReq.startTime(), // 시작 시간 설정
+						songReq.endTime(), // 종료 시간 설정
+						songReq.repeatCount() // 반복 횟수 설정
+					);
+					mapSongService.addSongToMap(savedMap.getId(), linkDto);
+				}
+			}
+		}
+		return new MapResponseDto(savedMap); // 저장된 맵 정보 반환
 	}
+
 
 	// 특정 맵 조회
 	@Transactional(readOnly = true)
@@ -46,18 +78,23 @@ public class MapService {
 	}
 
 	// 맵 정보 수정
-	@Transactional
 	public MapResponseDto updateMap(Long id, MapRequestDto requestDto) {
+		// 1. 해당 ID의 맵을 조회
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
 
+		// 2. 맵 소유자만 수정할 수 있도록 검증
 		if (!map.getUserId().equals(requestDto.userId())) {
 			throw new IllegalArgumentException("맵 수정 권한이 없습니다.");
 		}
 
+		// 3. 맵 정보 업데이트 (JPA가 엔티티를 관리하므로 변경 사항 자동 저장)
 		map.update(requestDto.name(), requestDto.description(), requestDto.isPublic());
+
+		// 4. 업데이트된 맵 정보 반환
 		return new MapResponseDto(map);
 	}
+
 
 	// 맵 삭제
 	@Transactional
@@ -72,6 +109,7 @@ public class MapService {
 		mapRepository.delete(map);
 	}
 
+	// 맵 이름 중복 체크
 	public boolean checkDuplicateMap(String name) {
 		return mapRepository.existsByName(name);
 	}

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -19,10 +19,6 @@ public class MapService {
 	@Transactional
 	public MapResponseDto createMap(MapRequestDto requestDto) {
 
-		if (mapRepository.existsByName(requestDto.name().trim())) {
-			throw new IllegalArgumentException("이미 존재하는 맵 이름입니다.");
-		}
-
 		Map map = Map.builder()
 			.userId(requestDto.userId())
 			.name(requestDto.name())
@@ -74,5 +70,16 @@ public class MapService {
 		}
 
 		mapRepository.delete(map);
+	}
+
+	public boolean checkDuplicateMap(String name) {
+		return mapRepository.existsByName(name);
+	}
+
+	// ✅ 중복 검사 시 예외 발생하도록 변경
+	public void validateDuplicateMap(String name) {
+		if (mapRepository.existsByName(name)) {
+			throw new IllegalArgumentException("이미 존재하는 맵 이름입니다: " + name);
+		}
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/MapSongService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapSongService.java
@@ -19,40 +19,58 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional
 public class MapSongService {
-
 	private final MapSongRepository mapSongRepository;
 	private final MapRepository mapRepository;
 	private final SongRepository songRepository;
+	// (선택 사항: 만약 SongService를 사용하여 노래를 생성하려면, 해당 서비스도 주입할 수 있음)
 
-	// 맵에 노래 추가
+	// 맵에 노래 추가 (기존 노래를 맵에 연결하거나, 필요한 경우 새 노래 생성 후 연결)
 	public MapSongResponseDto addSongToMap(Long mapId, MapSongRequestDto requestDto) {
+		// 1. 맵 엔티티 조회
 		Map map = mapRepository.findById(mapId)
 			.orElseThrow(() -> new IllegalArgumentException("맵을 찾을 수 없습니다."));
-		Song song = songRepository.findById(requestDto.songId())
-			.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다."));
 
+		// 2. 노래 엔티티 결정 (기존 노래 사용 또는 새 노래 생성)
+		Song song;
+		if (requestDto.songId() != null) {
+			// 기존 노래: ID로 조회
+			song = songRepository.findById(requestDto.songId())
+				.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다."));
+		} else if (requestDto.newSong() != null) {
+			// 새로운 노래 생성
+			Song newSong = Song.builder()
+				.title(requestDto.newSong().title()) // 제목 설정
+				.artist(requestDto.newSong().artist()) // 아티스트 설정
+				.composer(requestDto.newSong().composer()) // 작곡가 설정
+				.youtubeUrl(requestDto.newSong().youtubeUrl()) // 유튜브 URL 설정
+				.build();
+			song = songRepository.save(newSong); // 새 노래 저장
+		} else {
+			throw new IllegalArgumentException("노래 정보가 제공되지 않았습니다."); // songId 또는 newSong 둘 다 없을 경우 예외 발생
+		}
+
+		// 3. 맵과 노래 연결 엔티티 생성 및 저장
 		MapSong mapSong = MapSong.builder()
-			.map(map)
-			.song(song)
-			.startTime(requestDto.startTime())
-			.endTime(requestDto.endTime())
-			.repeatCount(requestDto.repeatCount())
+			.map(map) // 맵 설정
+			.song(song) // 노래 설정
+			.startTime(requestDto.startTime()) // 시작 시간 설정
+			.endTime(requestDto.endTime()) // 종료 시간 설정
+			.repeatCount(requestDto.repeatCount()) // 반복 횟수 설정
 			.build();
+		mapSongRepository.save(mapSong); // 저장
 
-		mapSongRepository.save(mapSong);
-		return new MapSongResponseDto(mapSong);
+		return new MapSongResponseDto(mapSong); // 저장된 정보 반환
 	}
 
-	// 특정 맵에 등록된 노래 조회
+	// 특정 맵에 등록된 모든 노래 조회
 	@Transactional(readOnly = true)
 	public List<MapSongResponseDto> getSongsByMapId(Long mapId) {
-		return mapSongRepository.findByMapId(mapId)
-			.stream()
+		return mapSongRepository.findByMapId(mapId).stream()
 			.map(MapSongResponseDto::new)
 			.collect(Collectors.toList());
 	}
 
-	// 특정 맵의 노래 삭제
+	// 특정 맵에서 노래 삭제 (맵과의 연결 해제)
 	public void removeSongFromMap(Long mapSongId) {
 		mapSongRepository.deleteById(mapSongId);
 	}

--- a/src/main/java/com/lshzzz/mato/service/SongService.java
+++ b/src/main/java/com/lshzzz/mato/service/SongService.java
@@ -29,7 +29,6 @@ public class SongService {
 			.composer(requestDto.composer())
 			.youtubeUrl(requestDto.youtubeUrl()) // 유튜브 URL 포함 가능
 			.build();
-
 		songRepository.save(song);
 		return new SongResponseDto(song);
 	}


### PR DESCRIPTION
💡 이슈
Close #14

🤩 개요
Map Song 관련 전반적인 CRUD 리펙토링

🧑‍💻 작업 사항
- MapRepository에 existsByName() 추가
- MapService에서 중복 검사 후 예외 발생하도록 변경
- `MapService`에서 맵 생성 후 `SongService` 및 `MapSongService`를 통해 노래 및 관계 저장
- `MapSongRequestDto` 수정: songId 필드 추가
- `MapSongController` 추가 및 기존 로직 개선
- `MapController`에서 중복 체크 로직 추가
- `SongService`의 노래 저장 로직 개선