### PR TITLE
Feat: answer hint api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+*.gz
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/lshzzz/mato/controller/AnswerController.java
+++ b/src/main/java/com/lshzzz/mato/controller/AnswerController.java
@@ -1,6 +1,8 @@
 package com.lshzzz.mato.controller;
 
 import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
+import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.service.AnswerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AnswerController {
 	private final AnswerService answerService;
+
+	@PostMapping("/{songId}/answers")
+	public ResponseEntity<List<AnswerResponseDto>> addAnswers(@PathVariable Long songId,
+		@RequestBody AnswerRequestDto requestDto) {
+		return ResponseEntity.ok(answerService.addAnswersToSong(songId, requestDto));
+	}
 
 	@GetMapping("/{songId}")
 	public ResponseEntity<List<AnswerDto>> getAnswers(@PathVariable Long songId) {

--- a/src/main/java/com/lshzzz/mato/controller/AnswerController.java
+++ b/src/main/java/com/lshzzz/mato/controller/AnswerController.java
@@ -1,0 +1,21 @@
+package com.lshzzz.mato.controller;
+
+import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.service.AnswerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/answers")
+@RequiredArgsConstructor
+public class AnswerController {
+	private final AnswerService answerService;
+
+	@GetMapping("/{songId}")
+	public ResponseEntity<List<AnswerDto>> getAnswers(@PathVariable Long songId) {
+		return ResponseEntity.ok(answerService.getAnswersBySong(songId));
+	}
+}

--- a/src/main/java/com/lshzzz/mato/controller/HintController.java
+++ b/src/main/java/com/lshzzz/mato/controller/HintController.java
@@ -1,6 +1,8 @@
 package com.lshzzz.mato.controller;
 
 import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.model.song.dto.HintRequestDto;
+import com.lshzzz.mato.model.song.dto.HintResponseDto;
 import com.lshzzz.mato.service.HintService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HintController {
 	private final HintService hintService;
+
+	@PostMapping("/{songId}/hints")
+	public ResponseEntity<List<HintResponseDto>> addHints(@PathVariable Long songId,
+		@RequestBody HintRequestDto requestDto) {
+		return ResponseEntity.ok(hintService.addHintsToSong(songId, requestDto));
+	}
 
 	@GetMapping("/{songId}")
 	public ResponseEntity<List<HintDto>> getHints(@PathVariable Long songId) {

--- a/src/main/java/com/lshzzz/mato/controller/HintController.java
+++ b/src/main/java/com/lshzzz/mato/controller/HintController.java
@@ -1,0 +1,21 @@
+package com.lshzzz.mato.controller;
+
+import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.service.HintService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hints")
+@RequiredArgsConstructor
+public class HintController {
+	private final HintService hintService;
+
+	@GetMapping("/{songId}")
+	public ResponseEntity<List<HintDto>> getHints(@PathVariable Long songId) {
+		return ResponseEntity.ok(hintService.getHintsBySong(songId));
+	}
+}

--- a/src/main/java/com/lshzzz/mato/model/song/Hint.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Hint.java
@@ -1,0 +1,40 @@
+package com.lshzzz.mato.model.song;
+
+import com.lshzzz.mato.model.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hints")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Hint extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY) // 🎯 하나의 노래에 여러 개의 힌트 가능
+	@JoinColumn(name = "song_id", nullable = false)
+	private Song song;
+
+	@Column(nullable = false)
+	private String hintText; // 🎯 힌트 내용 (ex. "OST", "3글자")
+
+	@Column(nullable = false)
+	private int hintTime; // 🎯 몇 초 후에 힌트를 보여줄 것인지 설정 (ex. 10초 후)
+}

--- a/src/main/java/com/lshzzz/mato/model/song/Hint.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Hint.java
@@ -36,5 +36,5 @@ public class Hint extends BaseEntity {
 	private String hintText; // 🎯 힌트 내용 (ex. "OST", "3글자")
 
 	@Column(nullable = false)
-	private int hintTime; // 🎯 몇 초 후에 힌트를 보여줄 것인지 설정 (ex. 10초 후)
+	private int revealTime; // 🎯 몇 초 후에 힌트를 보여줄 것인지 설정 (ex. 10초 후)
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerDto.java
@@ -1,0 +1,8 @@
+package com.lshzzz.mato.model.song.dto;
+
+public record AnswerDto(
+	Long id,
+	Long songId,
+	String answerText
+) {
+}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerRequestDto.java
@@ -1,0 +1,8 @@
+package com.lshzzz.mato.model.song.dto;
+
+import java.util.List;
+
+public record AnswerRequestDto(
+	List<String> answerTexts
+) {
+}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerResponseDto.java
@@ -1,0 +1,8 @@
+package com.lshzzz.mato.model.song.dto;
+
+public record AnswerResponseDto(
+	Long id,
+	Long songId,
+	String answerText
+) {
+}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintDto.java
@@ -1,6 +1,6 @@
 package com.lshzzz.mato.model.song.dto;
 
-public record HintRequestDto(
+public record HintDto(
 	Long id,
 	Long songId,
 	String hintText,

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
@@ -1,0 +1,9 @@
+package com.lshzzz.mato.model.song.dto;
+
+import java.util.List;
+
+public record HintRequestDto(
+	List<HintData> hints
+) {
+	public record HintData(String hintText, int revealTime) {}
+}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
@@ -1,0 +1,9 @@
+package com.lshzzz.mato.model.song.dto;
+
+public record HintRequestDto(
+	Long id,
+	Long songId,
+	String hintText,
+	int hintTime
+) {
+}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintResponseDto.java
@@ -1,0 +1,11 @@
+package com.lshzzz.mato.model.song.dto;
+
+import java.util.List;
+
+public record HintResponseDto(
+	Long id,
+	Long songId,
+	String hintText,
+	int revealTime
+) {
+}

--- a/src/main/java/com/lshzzz/mato/repository/AnswerRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/AnswerRepository.java
@@ -1,0 +1,10 @@
+package com.lshzzz.mato.repository;
+
+import com.lshzzz.mato.model.song.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+	List<Answer> findBySongId(Long songId);
+}

--- a/src/main/java/com/lshzzz/mato/repository/HintRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/HintRepository.java
@@ -1,0 +1,10 @@
+package com.lshzzz.mato.repository;
+
+import com.lshzzz.mato.model.song.Hint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HintRepository extends JpaRepository<Hint, Long> {
+	List<Hint> findBySongId(Long songId);
+}

--- a/src/main/java/com/lshzzz/mato/service/AnswerService.java
+++ b/src/main/java/com/lshzzz/mato/service/AnswerService.java
@@ -1,8 +1,14 @@
 package com.lshzzz.mato.service;
 
 import com.lshzzz.mato.model.song.Answer;
+import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
+import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.repository.AnswerRepository;
+import com.lshzzz.mato.repository.SongRepository;
+
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -12,6 +18,26 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AnswerService {
 	private final AnswerRepository answerRepository;
+	private final SongRepository songRepository;
+
+	@Transactional
+	public List<AnswerResponseDto> addAnswersToSong(Long songId, AnswerRequestDto requestDto) {
+		Song song = songRepository.findById(songId)
+			.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다. ID: " + songId));
+
+		List<Answer> answers = requestDto.answerTexts().stream()
+			.map(text -> Answer.builder()
+				.song(song)
+				.answerText(text)
+				.build())
+			.collect(Collectors.toList());
+
+		answerRepository.saveAll(answers);
+
+		return answers.stream()
+			.map(answer -> new AnswerResponseDto(answer.getId(), songId, answer.getAnswerText()))
+			.collect(Collectors.toList());
+	}
 
 	public List<AnswerDto> getAnswersBySong(Long songId) {
 		return answerRepository.findBySongId(songId)

--- a/src/main/java/com/lshzzz/mato/service/AnswerService.java
+++ b/src/main/java/com/lshzzz/mato/service/AnswerService.java
@@ -1,0 +1,22 @@
+package com.lshzzz.mato.service;
+
+import com.lshzzz.mato.model.song.Answer;
+import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.repository.AnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+	private final AnswerRepository answerRepository;
+
+	public List<AnswerDto> getAnswersBySong(Long songId) {
+		return answerRepository.findBySongId(songId)
+			.stream()
+			.map(answer -> new AnswerDto(answer.getId(), songId, answer.getAnswerText()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/lshzzz/mato/service/HintService.java
+++ b/src/main/java/com/lshzzz/mato/service/HintService.java
@@ -1,7 +1,14 @@
 package com.lshzzz.mato.service;
 
+import com.lshzzz.mato.model.song.Hint;
+import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.model.song.dto.HintRequestDto;
+import com.lshzzz.mato.model.song.dto.HintResponseDto;
 import com.lshzzz.mato.repository.HintRepository;
+import com.lshzzz.mato.repository.SongRepository;
+
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -11,11 +18,32 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HintService {
 	private final HintRepository hintRepository;
+	private final SongRepository songRepository;
+
+	@Transactional
+	public List<HintResponseDto> addHintsToSong(Long songId, HintRequestDto requestDto) {
+		Song song = songRepository.findById(songId)
+			.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다. ID: " + songId));
+
+		List<Hint> hints = requestDto.hints().stream()
+			.map(data -> Hint.builder()
+				.song(song)
+				.hintText(data.hintText())
+				.revealTime(data.revealTime())
+				.build())
+			.collect(Collectors.toList());
+
+		hintRepository.saveAll(hints);
+
+		return hints.stream()
+			.map(hint -> new HintResponseDto(hint.getId(), songId, hint.getHintText(), hint.getRevealTime()))
+			.collect(Collectors.toList());
+	}
 
 	public List<HintDto> getHintsBySong(Long songId) {
 		return hintRepository.findBySongId(songId)
 			.stream()
-			.map(hint -> new HintDto(hint.getId(), songId, hint.getHintText(), hint.getHintTime()))
+			.map(hint -> new HintDto(hint.getId(), songId, hint.getHintText(), hint.getRevealTime()))
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/HintService.java
+++ b/src/main/java/com/lshzzz/mato/service/HintService.java
@@ -1,0 +1,21 @@
+package com.lshzzz.mato.service;
+
+import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.repository.HintRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HintService {
+	private final HintRepository hintRepository;
+
+	public List<HintDto> getHintsBySong(Long songId) {
+		return hintRepository.findBySongId(songId)
+			.stream()
+			.map(hint -> new HintDto(hint.getId(), songId, hint.getHintText(), hint.getHintTime()))
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
## 📌 구현한 기능
- 정답 및 힌트 추가 API 개발  
- 정답과 힌트가 **여러 개 존재 가능**하도록 리스트 형태로 처리  
- `Song` 엔티티와 연결  
- `MapSong`과는 무관  

## 📌 주요 변경 사항
- `Answer` 및 `Hint` 엔티티 추가  
- DTO 및 Service 계층 구현  
- `AnswerController` 및 `HintController` 추가  

## 📌 테스트
- Postman을 이용해 정답/힌트 추가 확인 

Closed #18 
