### PR TITLE
Refactor: 백엔드 엔티티 및 서비스 구조 전면 리팩토링

### DIFF
--- a/src/main/java/com/lshzzz/mato/controller/AnswerController.java
+++ b/src/main/java/com/lshzzz/mato/controller/AnswerController.java
@@ -16,14 +16,15 @@ import java.util.List;
 public class AnswerController {
 	private final AnswerService answerService;
 
-	@PostMapping("/{songId}/answers")
-	public ResponseEntity<List<AnswerResponseDto>> addAnswers(@PathVariable Long songId,
+	@PostMapping("/{mapSongId}")
+	public ResponseEntity<List<AnswerResponseDto>> addAnswers(
+		@PathVariable Long mapSongId,
 		@RequestBody AnswerRequestDto requestDto) {
-		return ResponseEntity.ok(answerService.addAnswersToSong(songId, requestDto));
+		return ResponseEntity.ok(answerService.addAnswers(mapSongId, requestDto));
 	}
 
-	@GetMapping("/{songId}")
-	public ResponseEntity<List<AnswerDto>> getAnswers(@PathVariable Long songId) {
-		return ResponseEntity.ok(answerService.getAnswersBySong(songId));
+	@GetMapping("/{mapSongId}")
+	public ResponseEntity<List<AnswerDto>> getAnswers(@PathVariable Long mapSongId) {
+		return ResponseEntity.ok(answerService.getAnswersByMapSong(mapSongId));
 	}
 }

--- a/src/main/java/com/lshzzz/mato/controller/HintController.java
+++ b/src/main/java/com/lshzzz/mato/controller/HintController.java
@@ -16,14 +16,16 @@ import java.util.List;
 public class HintController {
 	private final HintService hintService;
 
-	@PostMapping("/{songId}/hints")
-	public ResponseEntity<List<HintResponseDto>> addHints(@PathVariable Long songId,
+	@PostMapping("/{mapSongId}")
+	public ResponseEntity<List<HintResponseDto>> addHints(
+		@PathVariable Long mapSongId,
 		@RequestBody HintRequestDto requestDto) {
-		return ResponseEntity.ok(hintService.addHintsToSong(songId, requestDto));
+		List<HintResponseDto> responses = hintService.addHintsToMapSong(mapSongId, requestDto);
+		return ResponseEntity.ok(responses);
 	}
 
-	@GetMapping("/{songId}")
-	public ResponseEntity<List<HintDto>> getHints(@PathVariable Long songId) {
-		return ResponseEntity.ok(hintService.getHintsBySong(songId));
+	@GetMapping("/{mapSongId}")
+	public ResponseEntity<List<HintDto>> getHints(@PathVariable Long mapSongId) {
+		return ResponseEntity.ok(hintService.getHintsByMapSong(mapSongId));
 	}
 }

--- a/src/main/java/com/lshzzz/mato/controller/MapController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapController.java
@@ -38,6 +38,11 @@ public class MapController {
 		}
 	}
 
+	@GetMapping("/check-duplicate")
+	public ResponseEntity<Boolean> checkDuplicateMap(@RequestParam String name) {
+		return ResponseEntity.ok(mapService.checkDuplicateMap(name));
+	}
+
 	// 특정 맵 정보 조회 (ID 기반)
 	@GetMapping("/{id}")
 	public ResponseEntity<MapResponseDto> getMap(@PathVariable Long id) {

--- a/src/main/java/com/lshzzz/mato/controller/MapSongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapSongController.java
@@ -6,6 +6,8 @@ import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
 import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.model.song.dto.HintRequestDto;
 import com.lshzzz.mato.model.song.dto.HintResponseDto;
+import com.lshzzz.mato.service.AnswerService;
+import com.lshzzz.mato.service.HintService;
 import com.lshzzz.mato.service.MapSongService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,37 +22,48 @@ import java.util.List;
 @RequestMapping("/api/maps")
 public class MapSongController {
 	private final MapSongService mapSongService;
+	private final AnswerService answerService;
+	private final HintService hintService;
 
-	// 특정 맵에 노래 추가 (기존 노래 또는 새로운 노래 등록 가능)
+	// ✅ 맵에 노래 추가
 	@PostMapping("/{mapId}/songs")
-	public ResponseEntity<MapSongResponseDto> addSongToMap(@PathVariable Long mapId,
-		@RequestBody @Valid MapSongRequestDto requestDto) {
+	public ResponseEntity<MapSongResponseDto> addSongToMap(
+		@PathVariable Long mapId,
+		@RequestBody @Valid MapSongRequestDto requestDto
+	) {
 		MapSongResponseDto added = mapSongService.addSongToMap(mapId, requestDto);
 		return ResponseEntity.status(HttpStatus.CREATED).body(added);
 	}
 
-	@PostMapping("/answers")
+
+	// ✅ 정답 추가 (맵-노래 기준)
+	@PostMapping("/songs/{mapSongId}/answers")
 	public ResponseEntity<List<AnswerResponseDto>> addAnswers(
-		@RequestBody AnswerRequestDto requestDto) {
-		List<AnswerResponseDto> responses = answerService.addAnswers(requestDto);
+		@PathVariable Long mapSongId,
+		@RequestBody AnswerRequestDto requestDto
+	) {
+		List<AnswerResponseDto> responses = answerService.addAnswers(mapSongId, requestDto);
 		return ResponseEntity.ok(responses);
 	}
 
-	@PostMapping("/hints")
+	// ✅ 힌트 추가 (맵-노래 기준)
+	@PostMapping("/songs/{mapSongId}/hints")
 	public ResponseEntity<List<HintResponseDto>> addHints(
-		@RequestBody HintRequestDto requestDto) {
-		List<HintResponseDto> responses = hintService.addHints(requestDto);
+		@PathVariable Long mapSongId,
+		@RequestBody HintRequestDto requestDto
+	) {
+		List<HintResponseDto> responses = hintService.addHintsToMapSong(mapSongId, requestDto);
 		return ResponseEntity.ok(responses);
 	}
 
-	// 특정 맵에 연결된 모든 노래 조회
+	// ✅ 맵의 노래 목록 조회
 	@GetMapping("/{mapId}/songs")
 	public ResponseEntity<List<MapSongResponseDto>> getSongsByMap(@PathVariable Long mapId) {
 		List<MapSongResponseDto> songs = mapSongService.getSongsByMapId(mapId);
 		return ResponseEntity.ok(songs);
 	}
 
-	// 특정 맵에서 노래 제거 (MapSong ID 기준으로 삭제)
+	// ✅ 맵에서 노래 제거
 	@DeleteMapping("/songs/{mapSongId}")
 	public ResponseEntity<Void> removeSongFromMap(@PathVariable Long mapSongId) {
 		mapSongService.removeSongFromMap(mapSongId);

--- a/src/main/java/com/lshzzz/mato/controller/MapSongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapSongController.java
@@ -2,6 +2,10 @@ package com.lshzzz.mato.controller;
 
 import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
+import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
+import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
+import com.lshzzz.mato.model.song.dto.HintRequestDto;
+import com.lshzzz.mato.model.song.dto.HintResponseDto;
 import com.lshzzz.mato.service.MapSongService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +27,20 @@ public class MapSongController {
 		@RequestBody @Valid MapSongRequestDto requestDto) {
 		MapSongResponseDto added = mapSongService.addSongToMap(mapId, requestDto);
 		return ResponseEntity.status(HttpStatus.CREATED).body(added);
+	}
+
+	@PostMapping("/answers")
+	public ResponseEntity<List<AnswerResponseDto>> addAnswers(
+		@RequestBody AnswerRequestDto requestDto) {
+		List<AnswerResponseDto> responses = answerService.addAnswers(requestDto);
+		return ResponseEntity.ok(responses);
+	}
+
+	@PostMapping("/hints")
+	public ResponseEntity<List<HintResponseDto>> addHints(
+		@RequestBody HintRequestDto requestDto) {
+		List<HintResponseDto> responses = hintService.addHints(requestDto);
+		return ResponseEntity.ok(responses);
 	}
 
 	// 특정 맵에 연결된 모든 노래 조회

--- a/src/main/java/com/lshzzz/mato/model/map/Map.java
+++ b/src/main/java/com/lshzzz/mato/model/map/Map.java
@@ -1,5 +1,6 @@
 package com.lshzzz.mato.model.map;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +44,9 @@ public class Map extends BaseEntity {
 
 	@Column(name = "map_status", nullable = false)
 	private Boolean isPublic;
+
+	@OneToMany(mappedBy = "map", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<MapSong> mapSongs = new ArrayList<>();
 
 	public void update(String name, String description, Boolean isPublic) {
 		this.name = name;

--- a/src/main/java/com/lshzzz/mato/model/map/dto/MapResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/map/dto/MapResponseDto.java
@@ -1,19 +1,29 @@
 package com.lshzzz.mato.model.map.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.lshzzz.mato.model.map.Map;
+import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
 
 public record MapResponseDto(
 	Long id,
 	String name,
 	String description,
 	Boolean isPublic,
-	LocalDateTime createdAt,
-	LocalDateTime updatedAt
+	List<MapSongResponseDto> songs,
+	LocalDateTime CreatedAt,
+	LocalDateTime UpdatedAt
 ) {
-	public MapResponseDto(Map map) {
-		this(map.getId(), map.getName(), map.getDescription(), map.getIsPublic(),
-			map.getCreatedAt(), map.getUpdatedAt());
+	public MapResponseDto(Map map, List<MapSongResponseDto> songs) {
+		this(
+			map.getId(),
+			map.getName(),
+			map.getDescription(),
+			map.getIsPublic(),
+			songs,
+			map.getCreatedAt(),
+			map.getUpdatedAt()
+		);
 	}
 }

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
@@ -60,5 +60,4 @@ public class MapSong extends BaseEntity {
 	@OneToMany(mappedBy = "mapSong", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Hint> hints = new ArrayList<>();
 
-
 }

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/MapSong.java
@@ -1,9 +1,15 @@
 package com.lshzzz.mato.model.mapsongs;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.lshzzz.mato.model.BaseEntity;
 import com.lshzzz.mato.model.map.Map;
+import com.lshzzz.mato.model.song.Answer;
+import com.lshzzz.mato.model.song.Hint;
 import com.lshzzz.mato.model.song.Song;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -46,5 +53,12 @@ public class MapSong extends BaseEntity {
 
 	@Column(nullable = false)
 	private Integer repeatCount; // 반복 횟수
+
+	@OneToMany(mappedBy = "mapSong", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Answer> answers = new ArrayList<>();
+
+	@OneToMany(mappedBy = "mapSong", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Hint> hints = new ArrayList<>();
+
 
 }

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongResponseDto.java
@@ -1,8 +1,10 @@
 package com.lshzzz.mato.model.mapsongs.dto;
 
 import com.lshzzz.mato.model.mapsongs.MapSong;
+import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.model.song.dto.HintDto;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record MapSongResponseDto(
 	Long id,
@@ -11,10 +13,10 @@ public record MapSongResponseDto(
 	Integer startTime,
 	Integer endTime,
 	Integer repeatCount,
-	LocalDateTime createdAt,
-	LocalDateTime updatedAt
+	List<AnswerDto> answers,
+	List<HintDto> hints
 ) {
-	public MapSongResponseDto(MapSong mapSong) {
+	public MapSongResponseDto(MapSong mapSong, List<AnswerDto> answers, List<HintDto> hints) {
 		this(
 			mapSong.getId(),
 			mapSong.getMap().getId(),
@@ -22,8 +24,8 @@ public record MapSongResponseDto(
 			mapSong.getStartTime(),
 			mapSong.getEndTime(),
 			mapSong.getRepeatCount(),
-			mapSong.getCreatedAt(),
-			mapSong.getUpdatedAt()
+			answers,
+			hints
 		);
 	}
 }

--- a/src/main/java/com/lshzzz/mato/model/song/Answer.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Answer.java
@@ -1,6 +1,7 @@
 package com.lshzzz.mato.model.song;
 
 import com.lshzzz.mato.model.BaseEntity;
+import com.lshzzz.mato.model.mapsongs.MapSong;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,9 +30,9 @@ public class Answer extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY) // 🎯 하나의 노래에 여러 개의 정답 가능
-	@JoinColumn(name = "song_id", nullable = false)
-	private Song song;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "map_song_id", nullable = false)
+	private MapSong mapSong;
 
 	@Column(nullable = false)
 	private String answerText; // 🎯 정답 문구 (ex. "사랑인가봐", "Love Maybe")

--- a/src/main/java/com/lshzzz/mato/model/song/Hint.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Hint.java
@@ -1,6 +1,7 @@
 package com.lshzzz.mato.model.song;
 
 import com.lshzzz.mato.model.BaseEntity;
+import com.lshzzz.mato.model.mapsongs.MapSong;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,9 +29,9 @@ public class Hint extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY) // 🎯 하나의 노래에 여러 개의 힌트 가능
-	@JoinColumn(name = "song_id", nullable = false)
-	private Song song;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "map_song_id", nullable = false)
+	private MapSong mapSong;
 
 	@Column(nullable = false)
 	private String hintText; // 🎯 힌트 내용 (ex. "OST", "3글자")

--- a/src/main/java/com/lshzzz/mato/model/song/Song.java
+++ b/src/main/java/com/lshzzz/mato/model/song/Song.java
@@ -20,23 +20,11 @@ public class Song extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, length = 100)
-	private String title; // 노래 제목
-
-	@Column(nullable = false, length = 50)
-	private String artist; // 가수
-
-	@Column(length = 50)
-	private String composer; // 작곡가
-
 	@Column(nullable = false)
 	private String youtubeUrl; // 오디오 파일 URL (유튜브 OR 직접 업로드)
 
 	// 업데이트 메서드
-	public void update(String title, String artist, String composer, String youtubeUrl) {
-		this.title = title;
-		this.artist = artist;
-		this.composer = composer;
+	public void update(String youtubeUrl) {
 		this.youtubeUrl = youtubeUrl;
 	}
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerDto.java
@@ -2,7 +2,7 @@ package com.lshzzz.mato.model.song.dto;
 
 public record AnswerDto(
 	Long id,
-	Long songId,
+	Long mapSongId,
 	String answerText
 ) {
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerRequestDto.java
@@ -3,6 +3,7 @@ package com.lshzzz.mato.model.song.dto;
 import java.util.List;
 
 public record AnswerRequestDto(
+	Long mapSongId,
 	List<String> answerTexts
 ) {
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/AnswerResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/AnswerResponseDto.java
@@ -1,8 +1,13 @@
 package com.lshzzz.mato.model.song.dto;
 
+import com.lshzzz.mato.model.song.Answer;
+
 public record AnswerResponseDto(
 	Long id,
-	Long songId,
+	Long mapSongId,
 	String answerText
 ) {
+	public AnswerResponseDto(Answer answer) {
+		this(answer.getId(), answer.getMapSong().getId(), answer.getAnswerText());
+	}
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintDto.java
@@ -2,7 +2,7 @@ package com.lshzzz.mato.model.song.dto;
 
 public record HintDto(
 	Long id,
-	Long songId,
+	Long mapSongId,
 	String hintText,
 	int hintTime
 ) {

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintRequestDto.java
@@ -3,6 +3,7 @@ package com.lshzzz.mato.model.song.dto;
 import java.util.List;
 
 public record HintRequestDto(
+	Long mapSongId,
 	List<HintData> hints
 ) {
 	public record HintData(String hintText, int revealTime) {}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/HintResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/HintResponseDto.java
@@ -1,11 +1,14 @@
 package com.lshzzz.mato.model.song.dto;
 
-import java.util.List;
+import com.lshzzz.mato.model.song.Hint;
 
 public record HintResponseDto(
 	Long id,
-	Long songId,
+	Long mapSongId,
 	String hintText,
 	int revealTime
 ) {
+	public HintResponseDto(Hint hint) {
+		this(hint.getId(), hint.getMapSong().getId(), hint.getHintText(), hint.getRevealTime());
+	}
 }

--- a/src/main/java/com/lshzzz/mato/model/song/dto/SongRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/SongRequestDto.java
@@ -3,8 +3,5 @@ package com.lshzzz.mato.model.song.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record SongRequestDto(
-	@NotBlank String title,    // 제목
-	@NotBlank String artist,   // 가수
-	String composer,           // 작곡가 (옵션)
 	@NotBlank String youtubeUrl  // 오디오 URL (유튜브 링크 OR 업로드된 파일)
 ) {}

--- a/src/main/java/com/lshzzz/mato/model/song/dto/SongResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/song/dto/SongResponseDto.java
@@ -1,26 +1,16 @@
 package com.lshzzz.mato.model.song.dto;
 
-import com.lshzzz.mato.model.song.Song;
 import java.time.LocalDateTime;
+
+import com.lshzzz.mato.model.song.Song;
 
 public record SongResponseDto(
 	Long id,
-	String title,
-	String artist,
-	String composer,
 	String youtubeUrl,
 	LocalDateTime createdAt,
 	LocalDateTime updatedAt
 ) {
 	public SongResponseDto(Song song) {
-		this(
-			song.getId(),
-			song.getTitle(),
-			song.getArtist(),
-			song.getComposer(),
-			song.getYoutubeUrl(),
-			song.getCreatedAt(),
-			song.getUpdatedAt()
-		);
+		this(song.getId(), song.getYoutubeUrl(), song.getCreatedAt(), song.getUpdatedAt());
 	}
 }

--- a/src/main/java/com/lshzzz/mato/repository/AnswerRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/AnswerRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-	List<Answer> findBySongId(Long songId);
+	List<Answer> findByMapSongId(Long mapSongId);
+
 }

--- a/src/main/java/com/lshzzz/mato/repository/HintRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/HintRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface HintRepository extends JpaRepository<Hint, Long> {
-	List<Hint> findBySongId(Long songId);
+	List<Hint> findByMapSongId(Long mapSongId);
 }

--- a/src/main/java/com/lshzzz/mato/repository/MapSongRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/MapSongRepository.java
@@ -1,14 +1,17 @@
 package com.lshzzz.mato.repository;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.lshzzz.mato.model.map.Map;
 import com.lshzzz.mato.model.mapsongs.MapSong;
 
 @Repository
 public interface MapSongRepository extends JpaRepository<MapSong, Long> {
 	List<MapSong> findByMapId(Long mapId);
 
+	List<MapSong> findByMap(Map map);
 }

--- a/src/main/java/com/lshzzz/mato/repository/SongRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/SongRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.lshzzz.mato.model.song.Song;
 
 public interface SongRepository extends JpaRepository<Song, Long> {
-	Optional<Song> findByTitleAndArtist(String title, String artist);
 }

--- a/src/main/java/com/lshzzz/mato/service/AnswerService.java
+++ b/src/main/java/com/lshzzz/mato/service/AnswerService.java
@@ -1,11 +1,13 @@
 package com.lshzzz.mato.service;
 
+import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Answer;
 import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
 import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
 import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.repository.AnswerRepository;
+import com.lshzzz.mato.repository.MapSongRepository;
 import com.lshzzz.mato.repository.SongRepository;
 
 import jakarta.transaction.Transactional;
@@ -18,31 +20,31 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AnswerService {
 	private final AnswerRepository answerRepository;
-	private final SongRepository songRepository;
+	private final MapSongRepository mapSongRepository;
 
 	@Transactional
-	public List<AnswerResponseDto> addAnswersToSong(Long songId, AnswerRequestDto requestDto) {
-		Song song = songRepository.findById(songId)
-			.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다. ID: " + songId));
+	public List<AnswerResponseDto> addAnswers(Long mapSongId, AnswerRequestDto requestDto) {
+		MapSong mapSong = mapSongRepository.findById(mapSongId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 맵-노래(mapSong)를 찾을 수 없습니다. ID: " + mapSongId));
 
 		List<Answer> answers = requestDto.answerTexts().stream()
 			.map(text -> Answer.builder()
-				.song(song)
+				.mapSong(mapSong)
 				.answerText(text)
 				.build())
-			.collect(Collectors.toList());
+			.toList();
 
 		answerRepository.saveAll(answers);
 
 		return answers.stream()
-			.map(answer -> new AnswerResponseDto(answer.getId(), songId, answer.getAnswerText()))
-			.collect(Collectors.toList());
+			.map(AnswerResponseDto::new)
+			.toList();
 	}
 
-	public List<AnswerDto> getAnswersBySong(Long songId) {
-		return answerRepository.findBySongId(songId)
+	public List<AnswerDto> getAnswersByMapSong(Long mapSongId) {
+		return answerRepository.findByMapSongId(mapSongId)
 			.stream()
-			.map(answer -> new AnswerDto(answer.getId(), songId, answer.getAnswerText()))
-			.collect(Collectors.toList());
+			.map(answer -> new AnswerDto(answer.getId(), mapSongId, answer.getAnswerText()))
+			.toList();
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/HintService.java
+++ b/src/main/java/com/lshzzz/mato/service/HintService.java
@@ -1,11 +1,13 @@
 package com.lshzzz.mato.service;
 
+import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Hint;
 import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.HintDto;
 import com.lshzzz.mato.model.song.dto.HintRequestDto;
 import com.lshzzz.mato.model.song.dto.HintResponseDto;
 import com.lshzzz.mato.repository.HintRepository;
+import com.lshzzz.mato.repository.MapSongRepository;
 import com.lshzzz.mato.repository.SongRepository;
 
 import jakarta.transaction.Transactional;
@@ -18,32 +20,31 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HintService {
 	private final HintRepository hintRepository;
-	private final SongRepository songRepository;
+	private final MapSongRepository mapSongRepository;
 
 	@Transactional
-	public List<HintResponseDto> addHintsToSong(Long songId, HintRequestDto requestDto) {
-		Song song = songRepository.findById(songId)
-			.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다. ID: " + songId));
+	public List<HintResponseDto> addHintsToMapSong(Long mapSongId, HintRequestDto requestDto) {
+		MapSong mapSong = mapSongRepository.findById(mapSongId)
+			.orElseThrow(() -> new IllegalArgumentException("MapSong 없음"));
 
 		List<Hint> hints = requestDto.hints().stream()
 			.map(data -> Hint.builder()
-				.song(song)
+				.mapSong(mapSong)
 				.hintText(data.hintText())
 				.revealTime(data.revealTime())
 				.build())
-			.collect(Collectors.toList());
+			.toList();
 
 		hintRepository.saveAll(hints);
 
 		return hints.stream()
-			.map(hint -> new HintResponseDto(hint.getId(), songId, hint.getHintText(), hint.getRevealTime()))
-			.collect(Collectors.toList());
+			.map(hint -> new HintResponseDto(hint.getId(), mapSongId, hint.getHintText(), hint.getRevealTime()))
+			.toList();
 	}
 
-	public List<HintDto> getHintsBySong(Long songId) {
-		return hintRepository.findBySongId(songId)
-			.stream()
-			.map(hint -> new HintDto(hint.getId(), songId, hint.getHintText(), hint.getRevealTime()))
-			.collect(Collectors.toList());
+	public List<HintDto> getHintsByMapSong(Long mapSongId) {
+		return hintRepository.findByMapSongId(mapSongId).stream()
+			.map(h -> new HintDto(h.getId(), h.getMapSong().getId(), h.getHintText(), h.getRevealTime()))
+			.toList();
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -4,95 +4,93 @@ import com.lshzzz.mato.model.map.Map;
 import com.lshzzz.mato.model.map.dto.MapRequestDto;
 import com.lshzzz.mato.model.map.dto.MapResponseDto;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
+import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
+import com.lshzzz.mato.model.song.Song;
+import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.model.song.dto.HintDto;
 import com.lshzzz.mato.model.song.dto.SongRequestDto;
 import com.lshzzz.mato.model.song.dto.SongResponseDto;
 import com.lshzzz.mato.repository.MapRepository;
+import com.lshzzz.mato.repository.MapSongRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MapService {
 	private final MapRepository mapRepository;
+	private final MapSongRepository mapSongRepository;
 	private final SongService songService;
 	private final MapSongService mapSongService;
 
 	// 맵 생성
 	@Transactional
 	public MapResponseDto createMap(MapRequestDto requestDto) {
-		// 1. 맵(Map) 엔티티 생성 및 저장
-		Map map = Map.builder()
-			.userId(requestDto.userId()) // 사용자 ID 설정
-			.name(requestDto.name()) // 맵 이름 설정
-			.description(requestDto.description()) // 맵 설명 설정
-			.isPublic(requestDto.isPublic()) // 공개 여부 설정
-			.build();
 
-		Map savedMap = mapRepository.save(map); // 맵 저장
+		Map map = mapRepository.save(
+			Map.builder()
+				.userId(requestDto.userId())
+				.name(requestDto.name())
+				.description(requestDto.description())
+				.isPublic(requestDto.isPublic())
+				.build()
+		);
 
-		// 2. 노래 목록이 제공된 경우, 각 노래를 맵에 추가
-		List<MapSongRequestDto> songsToAdd = requestDto.songs();
-		if (songsToAdd != null) {
-			for (MapSongRequestDto songReq : songsToAdd) {
+		if (requestDto.songs() != null) {
+			for (MapSongRequestDto songReq : requestDto.songs()) {
 				if (songReq.songId() != null) {
-					// 기존에 존재하는 노래일 경우: 맵과 연결만 수행
-					mapSongService.addSongToMap(savedMap.getId(), songReq);
+					mapSongService.addSongToMap(map.getId(), songReq);
 				} else if (songReq.newSong() != null) {
-					// 새로운 노래일 경우: 먼저 생성한 후 맵과 연결
-					SongRequestDto newSongInfo = songReq.newSong();
-					SongResponseDto createdSong = songService.createSong(newSongInfo);
-
-					// 생성된 노래의 ID를 가져와서 맵에 추가
-					Long newSongId = createdSong.id();
+					SongResponseDto createdSong = songService.createSong(songReq.newSong());
 					MapSongRequestDto linkDto = new MapSongRequestDto(
-						newSongId,
-						null,  // 이미 생성된 노래이므로 SongRequestDto 불필요
-						songReq.startTime(), // 시작 시간 설정
-						songReq.endTime(), // 종료 시간 설정
-						songReq.repeatCount() // 반복 횟수 설정
+						createdSong.id(),
+						null,
+						songReq.startTime(),
+						songReq.endTime(),
+						songReq.repeatCount()
 					);
-					mapSongService.addSongToMap(savedMap.getId(), linkDto);
+					mapSongService.addSongToMap(map.getId(), linkDto);
 				}
 			}
 		}
-		return new MapResponseDto(savedMap); // 저장된 맵 정보 반환
-	}
 
+		return buildMapResponseDto(map);
+	}
 
 	// 특정 맵 조회
 	@Transactional(readOnly = true)
-	public MapResponseDto getMapById(Long id) {
-		Map map = mapRepository.findById(id)
-			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
-		return new MapResponseDto(map);
+	public MapResponseDto getMapById(Long mapId) {
+		Map map = mapRepository.findById(mapId)
+			.orElseThrow(() -> new RuntimeException("맵이 존재하지 않습니다."));
+		return buildMapResponseDto(map);
 	}
 
-	// 공개된 맵 목록 조회
+
+	// 모든 공개된 맵 조회
 	@Transactional(readOnly = true)
 	public List<MapResponseDto> getPublicMaps() {
-		List<Map> maps = mapRepository.findByIsPublicTrue();
-		return maps.stream().map(MapResponseDto::new).toList();
+		return mapRepository.findByIsPublicTrue().stream()
+			.map(this::buildMapResponseDto)
+			.toList();
 	}
 
-	// 맵 정보 수정
+	// 맵 수정
+	@Transactional
 	public MapResponseDto updateMap(Long id, MapRequestDto requestDto) {
-		// 1. 해당 ID의 맵을 조회
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
 
-		// 2. 맵 소유자만 수정할 수 있도록 검증
 		if (!map.getUserId().equals(requestDto.userId())) {
 			throw new IllegalArgumentException("맵 수정 권한이 없습니다.");
 		}
 
-		// 3. 맵 정보 업데이트 (JPA가 엔티티를 관리하므로 변경 사항 자동 저장)
 		map.update(requestDto.name(), requestDto.description(), requestDto.isPublic());
-
-		// 4. 업데이트된 맵 정보 반환
-		return new MapResponseDto(map);
+		return buildMapResponseDto(map);
 	}
 
 
@@ -101,11 +99,9 @@ public class MapService {
 	public void deleteMap(Long id, Long userId) {
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
-
 		if (!map.getUserId().equals(userId)) {
 			throw new IllegalArgumentException("맵 삭제 권한이 없습니다.");
 		}
-
 		mapRepository.delete(map);
 	}
 
@@ -119,5 +115,36 @@ public class MapService {
 		if (mapRepository.existsByName(name)) {
 			throw new IllegalArgumentException("이미 존재하는 맵 이름입니다: " + name);
 		}
+	}
+
+	// 🔁 Map → MapResponseDto 변환 함수
+	private MapResponseDto buildMapResponseDto(Map map) {
+		List<MapSongResponseDto> mapSongDtos = mapSongRepository.findByMap(map).stream()
+			.map(mapSong -> {
+				List<AnswerDto> answers = mapSong.getAnswers().stream()
+					.map(a -> new AnswerDto(a.getId(), a.getMapSong().getId(), a.getAnswerText()))
+					.toList();
+
+				List<HintDto> hints = mapSong.getHints().stream()
+					.map(h -> new HintDto(h.getId(), h.getMapSong().getId(),h.getHintText(), h.getRevealTime()))
+					.toList();
+
+				Song song = mapSong.getSong();
+
+				return new MapSongResponseDto(
+					mapSong.getId(),
+					map.getId(),
+					song.getId(),
+					mapSong.getStartTime(),
+					mapSong.getEndTime(),
+					mapSong.getRepeatCount(),
+					answers,
+					hints
+				);
+			})
+			.toList();
+
+		// 🔥 여기서 깔끔하게 생성자 사용!
+		return new MapResponseDto(map, mapSongDtos);
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/MapSongService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapSongService.java
@@ -5,6 +5,8 @@ import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
 import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
 import com.lshzzz.mato.model.song.Song;
+import com.lshzzz.mato.model.song.dto.AnswerDto;
+import com.lshzzz.mato.model.song.dto.HintDto;
 import com.lshzzz.mato.repository.MapRepository;
 import com.lshzzz.mato.repository.MapSongRepository;
 import com.lshzzz.mato.repository.SongRepository;
@@ -13,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,56 +23,72 @@ public class MapSongService {
 	private final MapSongRepository mapSongRepository;
 	private final MapRepository mapRepository;
 	private final SongRepository songRepository;
-	// (선택 사항: 만약 SongService를 사용하여 노래를 생성하려면, 해당 서비스도 주입할 수 있음)
 
-	// 맵에 노래 추가 (기존 노래를 맵에 연결하거나, 필요한 경우 새 노래 생성 후 연결)
+	// 맵에 노래 추가
 	public MapSongResponseDto addSongToMap(Long mapId, MapSongRequestDto requestDto) {
-		// 1. 맵 엔티티 조회
 		Map map = mapRepository.findById(mapId)
 			.orElseThrow(() -> new IllegalArgumentException("맵을 찾을 수 없습니다."));
 
-		// 2. 노래 엔티티 결정 (기존 노래 사용 또는 새 노래 생성)
-		Song song;
-		if (requestDto.songId() != null) {
-			// 기존 노래: ID로 조회
-			song = songRepository.findById(requestDto.songId())
-				.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다."));
-		} else if (requestDto.newSong() != null) {
-			// 새로운 노래 생성
-			Song newSong = Song.builder()
-				.title(requestDto.newSong().title()) // 제목 설정
-				.artist(requestDto.newSong().artist()) // 아티스트 설정
-				.composer(requestDto.newSong().composer()) // 작곡가 설정
-				.youtubeUrl(requestDto.newSong().youtubeUrl()) // 유튜브 URL 설정
-				.build();
-			song = songRepository.save(newSong); // 새 노래 저장
-		} else {
-			throw new IllegalArgumentException("노래 정보가 제공되지 않았습니다."); // songId 또는 newSong 둘 다 없을 경우 예외 발생
-		}
-
-		// 3. 맵과 노래 연결 엔티티 생성 및 저장
+		Song song = resolveSong(requestDto);
 		MapSong mapSong = MapSong.builder()
-			.map(map) // 맵 설정
-			.song(song) // 노래 설정
-			.startTime(requestDto.startTime()) // 시작 시간 설정
-			.endTime(requestDto.endTime()) // 종료 시간 설정
-			.repeatCount(requestDto.repeatCount()) // 반복 횟수 설정
+			.map(map)
+			.song(song)
+			.startTime(requestDto.startTime())
+			.endTime(requestDto.endTime())
+			.repeatCount(requestDto.repeatCount())
 			.build();
-		mapSongRepository.save(mapSong); // 저장
 
-		return new MapSongResponseDto(mapSong); // 저장된 정보 반환
+		mapSongRepository.save(mapSong);
+		return convertToDto(mapSong);
 	}
 
-	// 특정 맵에 등록된 모든 노래 조회
+	// 맵에 연결된 노래 목록 조회
 	@Transactional(readOnly = true)
 	public List<MapSongResponseDto> getSongsByMapId(Long mapId) {
 		return mapSongRepository.findByMapId(mapId).stream()
-			.map(MapSongResponseDto::new)
-			.collect(Collectors.toList());
+			.map(this::convertToDto)
+			.toList();
 	}
 
-	// 특정 맵에서 노래 삭제 (맵과의 연결 해제)
+	// 노래 제거
 	public void removeSongFromMap(Long mapSongId) {
 		mapSongRepository.deleteById(mapSongId);
+	}
+
+	// 🔧 기존 노래 or 새 노래 생성 분기
+	private Song resolveSong(MapSongRequestDto requestDto) {
+		if (requestDto.songId() != null) {
+			return songRepository.findById(requestDto.songId())
+				.orElseThrow(() -> new IllegalArgumentException("노래를 찾을 수 없습니다."));
+		} else if (requestDto.newSong() != null) {
+			return songRepository.save(Song.builder()
+				.youtubeUrl(requestDto.newSong().youtubeUrl())
+				.build());
+		}
+		throw new IllegalArgumentException("노래 정보가 제공되지 않았습니다.");
+	}
+
+	// ✅ MapSong → MapSongResponseDto 변환 함수
+	private MapSongResponseDto convertToDto(MapSong mapSong) {
+		Song song = mapSong.getSong();
+
+		List<AnswerDto> answers = mapSong.getAnswers().stream()
+			.map(a -> new AnswerDto(a.getId(), a.getId(), a.getAnswerText()))
+			.toList();
+
+		List<HintDto> hints = mapSong.getHints().stream()
+			.map(h -> new HintDto(h.getId(), h.getId(), h.getHintText(), h.getRevealTime()))
+			.toList();
+
+		return new MapSongResponseDto(
+			mapSong.getId(),
+			mapSong.getMap().getId(),
+			song.getId(),
+			mapSong.getStartTime(),
+			mapSong.getEndTime(),
+			mapSong.getRepeatCount(),
+			answers,
+			hints
+		);
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/SongService.java
+++ b/src/main/java/com/lshzzz/mato/service/SongService.java
@@ -24,10 +24,7 @@ public class SongService {
 	// 노래 등록
 	public SongResponseDto createSong(SongRequestDto requestDto) {
 		Song song = Song.builder()
-			.title(requestDto.title())
-			.artist(requestDto.artist())
-			.composer(requestDto.composer())
-			.youtubeUrl(requestDto.youtubeUrl()) // 유튜브 URL 포함 가능
+			.youtubeUrl(requestDto.youtubeUrl())
 			.build();
 		songRepository.save(song);
 		return new SongResponseDto(song);
@@ -54,9 +51,6 @@ public class SongService {
 		Song song = songRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 노래입니다."));
 		song.update(
-			requestDto.title(),
-			requestDto.artist(),
-			requestDto.composer(),
 			requestDto.youtubeUrl()
 		);
 		return new SongResponseDto(song);


### PR DESCRIPTION
- 전체 백엔드 구조를 리팩토링하여 확장성과 유지보수를 고려한 구조로 개선하였습니다.
- Map, MapSong, Song, Answer, Hint 엔티티를 정리하고, 양방향 연관관계를 단방향으로 수정하였습니다.
- record 기반 DTO로 통일하고, 생성자 및 변환 로직을 간결화하였습니다.
- 서비스 계층 분리를 통해 각 역할의 책임을 명확히 분리하였습니다.
- 중복된 컬럼 이름, 빌더 혼용 등 오류 발생 가능성을 제거하였습니다.
- 정답/힌트 저장 방식을 Song → MapSong 단위로 변경하였습니다.
- 컨트롤러와 API 엔드포인트도 기능별로 명확히 나누어 RESTful하게 구성하였습니다.