### PR TITLE
백엔드 - 맵 수정 및 노래 수정 기능 개선

### DIFF
--- a/src/main/java/com/lshzzz/mato/controller/MapSongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapSongController.java
@@ -37,7 +37,6 @@ public class MapSongController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(added);
 	}
 
-
 	// ✅ 정답 추가 (맵-노래 기준)
 	@PostMapping("/songs/{mapSongId}/answers")
 	public ResponseEntity<List<AnswerResponseDto>> addAnswers(
@@ -68,7 +67,7 @@ public class MapSongController {
 		return ResponseEntity.ok(hintService.getHintsByMapSong(mapSongId));
 	}
 
-	@PatchMapping("/songs/{mapSongId}")
+	@PatchMapping("/{mapId}/songs/{mapSongId}")
 	public ResponseEntity<MapSongResponseDto> updateMapSong(
 		@PathVariable Long mapSongId,
 		@RequestBody @Valid MapSongRequestDto requestDto
@@ -77,7 +76,7 @@ public class MapSongController {
 		return ResponseEntity.ok(updated);
 	}
 
-	@PatchMapping("/songs/{mapSongId}/answers")
+	@PutMapping("/songs/{mapSongId}/answers")
 	public ResponseEntity<List<AnswerResponseDto>> updateAnswers(
 		@PathVariable Long mapSongId,
 		@RequestBody AnswerRequestDto requestDto
@@ -86,7 +85,7 @@ public class MapSongController {
 	}
 
 
-	@PatchMapping("/songs/{mapSongId}/hints")
+	@PutMapping("/songs/{mapSongId}/hints")
 	public ResponseEntity<List<HintResponseDto>> updateHints(
 		@PathVariable Long mapSongId,
 		@RequestBody HintRequestDto requestDto

--- a/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/mapsongs/dto/MapSongResponseDto.java
@@ -3,6 +3,7 @@ package com.lshzzz.mato.model.mapsongs.dto;
 import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
 import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.model.song.dto.SongResponseDto;
 
 import java.util.List;
 
@@ -13,10 +14,11 @@ public record MapSongResponseDto(
 	Integer startTime,
 	Integer endTime,
 	Integer repeatCount,
+	SongResponseDto song,
 	List<AnswerDto> answers,
 	List<HintDto> hints
 ) {
-	public MapSongResponseDto(MapSong mapSong, List<AnswerDto> answers, List<HintDto> hints) {
+	public MapSongResponseDto(MapSong mapSong, SongResponseDto songDto, List<AnswerDto> answers, List<HintDto> hints) {
 		this(
 			mapSong.getId(),
 			mapSong.getMap().getId(),
@@ -24,6 +26,7 @@ public record MapSongResponseDto(
 			mapSong.getStartTime(),
 			mapSong.getEndTime(),
 			mapSong.getRepeatCount(),
+			songDto, // ✅
 			answers,
 			hints
 		);

--- a/src/main/java/com/lshzzz/mato/service/AnswerService.java
+++ b/src/main/java/com/lshzzz/mato/service/AnswerService.java
@@ -2,19 +2,16 @@ package com.lshzzz.mato.service;
 
 import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Answer;
-import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
 import com.lshzzz.mato.model.song.dto.AnswerRequestDto;
 import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.repository.AnswerRepository;
 import com.lshzzz.mato.repository.MapSongRepository;
-import com.lshzzz.mato.repository.SongRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/lshzzz/mato/service/HintService.java
+++ b/src/main/java/com/lshzzz/mato/service/HintService.java
@@ -2,19 +2,16 @@ package com.lshzzz.mato.service;
 
 import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Hint;
-import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.HintDto;
 import com.lshzzz.mato.model.song.dto.HintRequestDto;
 import com.lshzzz.mato.model.song.dto.HintResponseDto;
 import com.lshzzz.mato.repository.HintRepository;
 import com.lshzzz.mato.repository.MapSongRepository;
-import com.lshzzz.mato.repository.SongRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -1,24 +1,20 @@
 package com.lshzzz.mato.service;
 
-import com.lshzzz.mato.model.map.Map;
-import com.lshzzz.mato.model.map.dto.MapRequestDto;
-import com.lshzzz.mato.model.map.dto.MapResponseDto;
-import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
-import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
-import com.lshzzz.mato.model.song.Song;
-import com.lshzzz.mato.model.song.dto.AnswerDto;
-import com.lshzzz.mato.model.song.dto.HintDto;
-import com.lshzzz.mato.model.song.dto.SongRequestDto;
-import com.lshzzz.mato.model.song.dto.SongResponseDto;
-import com.lshzzz.mato.repository.MapRepository;
-import com.lshzzz.mato.repository.MapSongRepository;
+import java.util.List;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import com.lshzzz.mato.model.map.Map;
+import com.lshzzz.mato.model.map.dto.MapRequestDto;
+import com.lshzzz.mato.model.map.dto.MapResponseDto;
+
+import com.lshzzz.mato.model.mapsongs.dto.MapSongRequestDto;
+import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
+import com.lshzzz.mato.model.song.dto.SongResponseDto;
+import com.lshzzz.mato.repository.MapRepository;
+import com.lshzzz.mato.repository.MapSongRepository;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +24,8 @@ public class MapService {
 	private final SongService songService;
 	private final MapSongService mapSongService;
 
-	// 맵 생성
 	@Transactional
 	public MapResponseDto createMap(MapRequestDto requestDto) {
-
 		Map map = mapRepository.save(
 			Map.builder()
 				.userId(requestDto.userId())
@@ -43,26 +37,13 @@ public class MapService {
 
 		if (requestDto.songs() != null) {
 			for (MapSongRequestDto songReq : requestDto.songs()) {
-				if (songReq.songId() != null) {
-					mapSongService.addSongToMap(map.getId(), songReq);
-				} else if (songReq.newSong() != null) {
-					SongResponseDto createdSong = songService.createSong(songReq.newSong());
-					MapSongRequestDto linkDto = new MapSongRequestDto(
-						createdSong.id(),
-						null,
-						songReq.startTime(),
-						songReq.endTime(),
-						songReq.repeatCount()
-					);
-					mapSongService.addSongToMap(map.getId(), linkDto);
-				}
+				handleSongRequest(map.getId(), songReq);
 			}
 		}
 
 		return buildMapResponseDto(map);
 	}
 
-	// 특정 맵 조회
 	@Transactional(readOnly = true)
 	public MapResponseDto getMapById(Long mapId) {
 		Map map = mapRepository.findById(mapId)
@@ -70,8 +51,6 @@ public class MapService {
 		return buildMapResponseDto(map);
 	}
 
-
-	// 모든 공개된 맵 조회
 	@Transactional(readOnly = true)
 	public List<MapResponseDto> getPublicMaps() {
 		return mapRepository.findByIsPublicTrue().stream()
@@ -79,7 +58,6 @@ public class MapService {
 			.toList();
 	}
 
-	// 맵 수정
 	@Transactional
 	public MapResponseDto updateMap(Long id, MapRequestDto requestDto) {
 		Map map = mapRepository.findById(id)
@@ -93,58 +71,49 @@ public class MapService {
 		return buildMapResponseDto(map);
 	}
 
-
-	// 맵 삭제
 	@Transactional
 	public void deleteMap(Long id, Long userId) {
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
+
 		if (!map.getUserId().equals(userId)) {
 			throw new IllegalArgumentException("맵 삭제 권한이 없습니다.");
 		}
+
 		mapRepository.delete(map);
 	}
 
-	// 맵 이름 중복 체크
 	public boolean checkDuplicateMap(String name) {
 		return mapRepository.existsByName(name);
 	}
 
-	// ✅ 중복 검사 시 예외 발생하도록 변경
 	public void validateDuplicateMap(String name) {
 		if (mapRepository.existsByName(name)) {
 			throw new IllegalArgumentException("이미 존재하는 맵 이름입니다: " + name);
 		}
 	}
 
-	// 🔁 Map → MapResponseDto 변환 함수
 	private MapResponseDto buildMapResponseDto(Map map) {
 		List<MapSongResponseDto> mapSongDtos = mapSongRepository.findByMap(map).stream()
-			.map(mapSong -> {
-				List<AnswerDto> answers = mapSong.getAnswers().stream()
-					.map(a -> new AnswerDto(a.getId(), a.getMapSong().getId(), a.getAnswerText()))
-					.toList();
-
-				List<HintDto> hints = mapSong.getHints().stream()
-					.map(h -> new HintDto(h.getId(), h.getMapSong().getId(),h.getHintText(), h.getRevealTime()))
-					.toList();
-
-				Song song = mapSong.getSong();
-
-				return new MapSongResponseDto(
-					mapSong.getId(),
-					map.getId(),
-					song.getId(),
-					mapSong.getStartTime(),
-					mapSong.getEndTime(),
-					mapSong.getRepeatCount(),
-					answers,
-					hints
-				);
-			})
+			.map(mapSongService::convertToDto)
 			.toList();
 
-		// 🔥 여기서 깔끔하게 생성자 사용!
 		return new MapResponseDto(map, mapSongDtos);
+	}
+
+	private void handleSongRequest(Long mapId, MapSongRequestDto songReq) {
+		if (songReq.songId() != null) {
+			mapSongService.addSongToMap(mapId, songReq);
+		} else if (songReq.newSong() != null) {
+			SongResponseDto createdSong = songService.createSong(songReq.newSong());
+			MapSongRequestDto linkDto = new MapSongRequestDto(
+				createdSong.id(),
+				null,
+				songReq.startTime(),
+				songReq.endTime(),
+				songReq.repeatCount()
+			);
+			mapSongService.addSongToMap(mapId, linkDto);
+		}
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/MapSongService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapSongService.java
@@ -7,16 +7,21 @@ import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
 import com.lshzzz.mato.model.song.Song;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
 import com.lshzzz.mato.model.song.dto.HintDto;
+import com.lshzzz.mato.model.song.dto.SongResponseDto;
 import com.lshzzz.mato.repository.MapRepository;
 import com.lshzzz.mato.repository.MapSongRepository;
 import com.lshzzz.mato.repository.SongRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -61,30 +66,37 @@ public class MapSongService {
 	// 노래 업데이트
 	@Transactional
 	public MapSongResponseDto updateMapSong(Long mapSongId, MapSongRequestDto requestDto) {
-		MapSong mapSong = mapSongRepository.findById(mapSongId)
-			.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다."));
+		try {
+			MapSong mapSong = mapSongRepository.findById(mapSongId)
+				.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다. ID=" + mapSongId));
 
-		// 🔁 노래 교체 or 새 노래 생성
-		Song song;
-		if (requestDto.songId() != null) {
-			song = songRepository.findById(requestDto.songId())
-				.orElseThrow(() -> new IllegalArgumentException("해당 Song ID 없음"));
-		} else if (requestDto.newSong() != null) {
-			song = Song.builder()
-				.youtubeUrl(requestDto.newSong().youtubeUrl())
-				// .title(requestDto.newSong().title()) 등 확장 가능
-				.build();
-			songRepository.save(song);
-		} else {
-			throw new IllegalArgumentException("수정할 Song 정보가 없습니다.");
+			Song song = mapSong.getSong();
+
+			if (requestDto.songId() != null) {
+				song = songRepository.findById(requestDto.songId())
+					.orElseThrow(() -> new IllegalArgumentException("해당 Song ID 없음: " + requestDto.songId()));
+			} else if (requestDto.newSong() != null) {
+				String url = Optional.ofNullable(requestDto.newSong().youtubeUrl())
+					.orElseThrow(() -> new IllegalArgumentException("youtubeUrl은 null일 수 없습니다."));
+				String title = Optional.ofNullable(requestDto.newSong().title()).orElse("제목 없음");
+
+				song = Song.builder()
+					.youtubeUrl(url)
+					.title(title)
+					.build();
+				songRepository.save(song);
+			}
+
+			mapSong.updateSong(song);
+			mapSong.updateTiming(requestDto.startTime(), requestDto.endTime(), requestDto.repeatCount());
+
+			return convertToDto(mapSong);
+		} catch (Exception e) {
+			log.error("🔴 MapSong 수정 중 예외 발생: {}", e.getMessage(), e);
+			throw new RuntimeException("MapSong 수정 중 오류 발생", e);  // 예외의 원인 포함
 		}
-
-		// ✅ mapSong 정보 수정
-		mapSong.updateSong(song);
-		mapSong.updateTiming(requestDto.startTime(), requestDto.endTime(), requestDto.repeatCount());
-
-		return convertToDto(mapSong);
 	}
+
 
 
 	// 노래 제거
@@ -106,16 +118,22 @@ public class MapSongService {
 	}
 
 	// ✅ MapSong → MapSongResponseDto 변환 함수
-	private MapSongResponseDto convertToDto(MapSong mapSong) {
+	public MapSongResponseDto convertToDto(MapSong mapSong) {
 		Song song = mapSong.getSong();
 
 		List<AnswerDto> answers = mapSong.getAnswers().stream()
+			.filter(a -> a != null && a.getAnswerText() != null)
 			.map(a -> new AnswerDto(a.getId(), a.getId(), a.getAnswerText()))
 			.toList();
 
+
 		List<HintDto> hints = mapSong.getHints().stream()
+			.filter(h -> h != null && h.getHintText() != null)
 			.map(h -> new HintDto(h.getId(), h.getId(), h.getHintText(), h.getRevealTime()))
 			.toList();
+
+
+		SongResponseDto songDto = new SongResponseDto(song); // ✅ 곡 정보 포함
 
 		return new MapSongResponseDto(
 			mapSong.getId(),
@@ -124,6 +142,7 @@ public class MapSongService {
 			mapSong.getStartTime(),
 			mapSong.getEndTime(),
 			mapSong.getRepeatCount(),
+			songDto,
 			answers,
 			hints
 		);


### PR DESCRIPTION
### 변경 사항:
- `MapService`:
  - `createMap` 메서드에서 맵 생성 시 노래 정보를 추가하는 로직을 개선.
  - 맵에 노래를 추가할 때 기존의 노래가 아니라 새 노래를 추가하는 경우에도 처리할 수 있도록 개선.
  - `updateMap` 메서드에서 맵의 수정 권한 체크를 강화하고, 수정된 맵을 반환하도록 처리.

- `MapSongService`:
  - 노래 수정 시 기존 노래를 업데이트하거나 새로운 노래를 추가하는 로직을 개선.
  - `resolveSong` 메서드를 사용해 기존 노래 또는 새 노래를 처리하도록 변경.
  - 예외 처리 및 로깅을 추가하여 안정성 및 디버깅을 용이하게 개선.

- `MapSongController`:
  - `MapSongResponseDto`에서 노래 정보와 함께 추가적인 세부 정보를 반환하도록 수정.
  - `addSongToMap`, `updateMapSong`, `removeSongFromMap` 등의 API 메서드를 개선하여 노래 추가, 수정, 삭제 기능을 더욱 확실히 처리.
  - `PUT` 방식으로 정답 및 힌트 업데이트 로직을 추가하여 상태 변경 시 일관성 있는 처리를 보장.