### PR TITLE
Feat: 맵 기능에 사용자 인증 및 노래 검색 기능 추가

### DIFF
--- a/src/main/java/com/lshzzz/mato/controller/MapController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapController.java
@@ -29,7 +29,6 @@ public class MapController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(createdMap);
 	}
 
-
 	@GetMapping("/check")
 	public ResponseEntity<?> checkMapExists(@RequestParam String name) {
 		try {
@@ -39,11 +38,6 @@ public class MapController {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 				.body(Collections.singletonMap("error", "중복 검사 중 오류 발생"));
 		}
-	}
-
-	@GetMapping("/check-duplicate")
-	public ResponseEntity<Boolean> checkDuplicateMap(@RequestParam String name) {
-		return ResponseEntity.ok(mapService.checkDuplicateMap(name));
 	}
 
 	// 특정 맵 정보 조회 (ID 기반)
@@ -58,6 +52,23 @@ public class MapController {
 	public ResponseEntity<List<MapResponseDto>> getPublicMaps() {
 		List<MapResponseDto> publicMaps = mapService.getPublicMaps();
 		return ResponseEntity.ok(publicMaps);
+	}
+
+	// 사용자별 맵 목록 조회
+	@GetMapping("/user/{userId}")
+	public ResponseEntity<List<MapResponseDto>> getMapsByUser(@PathVariable String userId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String authenticatedUserId = userDetails.getUsername();
+		// 본인 조회 또는 공개된 맵만 조회 가능
+		List<MapResponseDto> maps;
+		if (authenticatedUserId.equals(userId)) {
+			// 본인인 경우 모든 맵 조회
+			maps = mapService.getMapsByUserId(userId);
+		} else {
+			// 타인인 경우 공개된 맵만 조회
+			maps = mapService.getPublicMapsByUserId(userId);
+		}
+		return ResponseEntity.ok(maps);
 	}
 
 	// 맵 정보 수정

--- a/src/main/java/com/lshzzz/mato/controller/MapController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapController.java
@@ -2,10 +2,12 @@ package com.lshzzz.mato.controller;
 
 import com.lshzzz.mato.model.map.dto.MapRequestDto;
 import com.lshzzz.mato.model.map.dto.MapResponseDto;
+import com.lshzzz.mato.model.users.CustomUserDetails;
 import com.lshzzz.mato.service.MapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -19,13 +21,14 @@ import java.util.List;
 public class MapController {
 	private final MapService mapService;
 
-	// 새로운 맵 생성 (옵션: 노래 목록도 함께 추가 가능)
 	@PostMapping
-	public ResponseEntity<MapResponseDto> createMap(@RequestBody @Valid MapRequestDto requestDto) {
-		// 요청 DTO에는 맵 정보와 추가할 노래 목록(기존 또는 새로운 노래)이 포함됨
-		MapResponseDto createdMap = mapService.createMap(requestDto);
+	public ResponseEntity<MapResponseDto> createMap(@RequestBody @Valid MapRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String authenticatedUserId = userDetails.getUsername();
+		MapResponseDto createdMap = mapService.createMap(requestDto, authenticatedUserId);
 		return ResponseEntity.status(HttpStatus.CREATED).body(createdMap);
 	}
+
 
 	@GetMapping("/check")
 	public ResponseEntity<?> checkMapExists(@RequestParam String name) {
@@ -60,16 +63,19 @@ public class MapController {
 	// 맵 정보 수정
 	@PatchMapping("/{mapId}")
 	public ResponseEntity<MapResponseDto> updateMap(@PathVariable Long mapId,
-		@RequestBody @Valid MapRequestDto requestDto) {
-		MapResponseDto updatedMap = mapService.updateMap(mapId, requestDto);
+		@RequestBody @Valid MapRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String authenticatedUserId = userDetails.getUsername();
+		MapResponseDto updatedMap = mapService.updateMap(mapId, requestDto, authenticatedUserId);
 		return ResponseEntity.ok(updatedMap);
 	}
 
 	// 맵 삭제 (삭제 권한 검사를 위해 userId를 요청 파라미터로 전달)
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> deleteMap(@PathVariable Long id,
-		@RequestParam Long userId) {
-		mapService.deleteMap(id, userId);
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String authenticatedUserId = userDetails.getUsername();
+		mapService.deleteMap(id, authenticatedUserId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/lshzzz/mato/controller/MapSongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/MapSongController.java
@@ -8,12 +8,14 @@ import com.lshzzz.mato.model.song.dto.AnswerResponseDto;
 import com.lshzzz.mato.model.song.dto.HintDto;
 import com.lshzzz.mato.model.song.dto.HintRequestDto;
 import com.lshzzz.mato.model.song.dto.HintResponseDto;
+import com.lshzzz.mato.model.users.CustomUserDetails;
 import com.lshzzz.mato.service.AnswerService;
 import com.lshzzz.mato.service.HintService;
 import com.lshzzz.mato.service.MapSongService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -31,9 +33,11 @@ public class MapSongController {
 	@PostMapping("/{mapId}/songs")
 	public ResponseEntity<MapSongResponseDto> addSongToMap(
 		@PathVariable Long mapId,
-		@RequestBody @Valid MapSongRequestDto requestDto
+		@RequestBody @Valid MapSongRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		MapSongResponseDto added = mapSongService.addSongToMap(mapId, requestDto);
+		String authenticatedUserId = userDetails.getUsername();
+		MapSongResponseDto added = mapSongService.addSongToMap(mapId, requestDto, authenticatedUserId);
 		return ResponseEntity.status(HttpStatus.CREATED).body(added);
 	}
 
@@ -41,9 +45,11 @@ public class MapSongController {
 	@PostMapping("/songs/{mapSongId}/answers")
 	public ResponseEntity<List<AnswerResponseDto>> addAnswers(
 		@PathVariable Long mapSongId,
-		@RequestBody AnswerRequestDto requestDto
+		@RequestBody AnswerRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		List<AnswerResponseDto> responses = answerService.addAnswers(mapSongId, requestDto);
+		String authenticatedUserId = userDetails.getUsername();
+		List<AnswerResponseDto> responses = answerService.addAnswers(mapSongId, requestDto, authenticatedUserId);
 		return ResponseEntity.ok(responses);
 	}
 
@@ -56,9 +62,11 @@ public class MapSongController {
 	@PostMapping("/songs/{mapSongId}/hints")
 	public ResponseEntity<List<HintResponseDto>> addHints(
 		@PathVariable Long mapSongId,
-		@RequestBody HintRequestDto requestDto
+		@RequestBody HintRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		List<HintResponseDto> responses = hintService.addHintsToMapSong(mapSongId, requestDto);
+		String authenticatedUserId = userDetails.getUsername();
+		List<HintResponseDto> responses = hintService.addHintsToMapSong(mapSongId, requestDto, authenticatedUserId);
 		return ResponseEntity.ok(responses);
 	}
 
@@ -70,27 +78,33 @@ public class MapSongController {
 	@PatchMapping("/{mapId}/songs/{mapSongId}")
 	public ResponseEntity<MapSongResponseDto> updateMapSong(
 		@PathVariable Long mapSongId,
-		@RequestBody @Valid MapSongRequestDto requestDto
+		@RequestBody @Valid MapSongRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		MapSongResponseDto updated = mapSongService.updateMapSong(mapSongId, requestDto);
+		String authenticatedUserId = userDetails.getUsername();
+		MapSongResponseDto updated = mapSongService.updateMapSong(mapSongId, requestDto, authenticatedUserId);
 		return ResponseEntity.ok(updated);
 	}
 
 	@PutMapping("/songs/{mapSongId}/answers")
 	public ResponseEntity<List<AnswerResponseDto>> updateAnswers(
 		@PathVariable Long mapSongId,
-		@RequestBody AnswerRequestDto requestDto
+		@RequestBody AnswerRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(answerService.updateAnswers(mapSongId, requestDto));
+		String authenticatedUserId = userDetails.getUsername();
+		return ResponseEntity.ok(answerService.updateAnswers(mapSongId, requestDto, authenticatedUserId));
 	}
 
 
 	@PutMapping("/songs/{mapSongId}/hints")
 	public ResponseEntity<List<HintResponseDto>> updateHints(
 		@PathVariable Long mapSongId,
-		@RequestBody HintRequestDto requestDto
+		@RequestBody HintRequestDto requestDto,
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(hintService.updateHints(mapSongId, requestDto));
+		String authenticatedUserId = userDetails.getUsername();
+		return ResponseEntity.ok(hintService.updateHints(mapSongId, requestDto, authenticatedUserId));
 	}
 
 
@@ -103,8 +117,12 @@ public class MapSongController {
 
 	// ✅ 맵에서 노래 제거
 	@DeleteMapping("/songs/{mapSongId}")
-	public ResponseEntity<Void> removeSongFromMap(@PathVariable Long mapSongId) {
-		mapSongService.removeSongFromMap(mapSongId);
+	public ResponseEntity<Void> removeSongFromMap(
+		@PathVariable Long mapSongId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		String authenticatedUserId = userDetails.getUsername();
+		mapSongService.removeSongFromMap(mapSongId, authenticatedUserId);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/lshzzz/mato/controller/SongController.java
+++ b/src/main/java/com/lshzzz/mato/controller/SongController.java
@@ -54,4 +54,19 @@ public class SongController {
 		songService.deleteSong(id);
 		return ResponseEntity.noContent().build();
 	}
+
+	// URL로 노래 검색
+	@GetMapping("/search/url")
+	public ResponseEntity<SongResponseDto> searchByUrl(@RequestParam String youtubeUrl) {
+		Optional<SongResponseDto> song = songService.getSongByUrl(youtubeUrl);
+		return song.map(ResponseEntity::ok)
+			.orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+	}
+
+	// 제목으로 노래 검색
+	@GetMapping("/search/title")
+	public ResponseEntity<List<SongResponseDto>> searchByTitle(@RequestParam String title) {
+		List<SongResponseDto> songs = songService.searchSongsByTitle(title);
+		return ResponseEntity.ok(songs);
+	}
 }

--- a/src/main/java/com/lshzzz/mato/model/map/Map.java
+++ b/src/main/java/com/lshzzz/mato/model/map/Map.java
@@ -34,7 +34,7 @@ public class Map extends BaseEntity {
 	private Long id;
 
 	@Column(name = "user_id", nullable = false)
-	private Long userId; // 유저 ID (방장 또는 생성자)
+	private String userId; // 유저 ID (방장 또는 생성자)
 
 	@Column(name = "name", nullable = false, length = 50)
 	private String name; // 맵 이름

--- a/src/main/java/com/lshzzz/mato/model/map/dto/MapRequestDto.java
+++ b/src/main/java/com/lshzzz/mato/model/map/dto/MapRequestDto.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record MapRequestDto(
-	@NotNull Long userId,
+	@NotNull String userId,
 	@NotNull String name,
 	String description,
 	@NotNull Boolean isPublic,

--- a/src/main/java/com/lshzzz/mato/model/map/dto/MapResponseDto.java
+++ b/src/main/java/com/lshzzz/mato/model/map/dto/MapResponseDto.java
@@ -8,6 +8,7 @@ import com.lshzzz.mato.model.mapsongs.dto.MapSongResponseDto;
 
 public record MapResponseDto(
 	Long id,
+	String userId,
 	String name,
 	String description,
 	Boolean isPublic,
@@ -18,6 +19,7 @@ public record MapResponseDto(
 	public MapResponseDto(Map map, List<MapSongResponseDto> songs) {
 		this(
 			map.getId(),
+			map.getUserId(),
 			map.getName(),
 			map.getDescription(),
 			map.getIsPublic(),

--- a/src/main/java/com/lshzzz/mato/repository/MapRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/MapRepository.java
@@ -12,5 +12,10 @@ public interface MapRepository extends JpaRepository<Map, Long> {
 	List<Map> findByIsPublicTrue(); // 공개 맵 목록 조회
 
 	boolean existsByName(String name);
-
+	
+	// 사용자별 맵 목록 조회
+	List<Map> findByUserId(String userId);
+	
+	// 사용자별 공개 맵 목록 조회
+	List<Map> findByUserIdAndIsPublicTrue(String userId);
 }

--- a/src/main/java/com/lshzzz/mato/repository/SongRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/SongRepository.java
@@ -1,10 +1,16 @@
 package com.lshzzz.mato.repository;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.lshzzz.mato.model.song.Song;
 
 public interface SongRepository extends JpaRepository<Song, Long> {
+    // URL로 노래 검색
+    Optional<Song> findByYoutubeUrl(String youtubeUrl);
+    
+    // 제목으로 노래 검색 (부분 일치)
+    List<Song> findByTitleContaining(String title);
 }

--- a/src/main/java/com/lshzzz/mato/service/AnswerService.java
+++ b/src/main/java/com/lshzzz/mato/service/AnswerService.java
@@ -1,5 +1,6 @@
 package com.lshzzz.mato.service;
 
+import com.lshzzz.mato.model.map.Map;
 import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Answer;
 import com.lshzzz.mato.model.song.dto.AnswerDto;
@@ -19,10 +20,20 @@ public class AnswerService {
 	private final AnswerRepository answerRepository;
 	private final MapSongRepository mapSongRepository;
 
+	// 인증 검사 헬퍼 메서드
+	private void checkMapOwnership(Map map, String authenticatedUserId) {
+		if (!map.getUserId().equals(authenticatedUserId)) {
+			throw new IllegalArgumentException("맵에 대한 권한이 없습니다.");
+		}
+	}
+
 	@Transactional
-	public List<AnswerResponseDto> addAnswers(Long mapSongId, AnswerRequestDto requestDto) {
+	public List<AnswerResponseDto> addAnswers(Long mapSongId, AnswerRequestDto requestDto, String authenticatedUserId) {
 		MapSong mapSong = mapSongRepository.findById(mapSongId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 맵-노래(mapSong)를 찾을 수 없습니다. ID: " + mapSongId));
+			
+		// 인증 검사
+		checkMapOwnership(mapSong.getMap(), authenticatedUserId);
 
 		List<Answer> answers = requestDto.answerTexts().stream()
 			.map(text -> Answer.builder()
@@ -46,9 +57,12 @@ public class AnswerService {
 	}
 
 	@Transactional
-	public List<AnswerResponseDto> updateAnswers(Long mapSongId, AnswerRequestDto requestDto) {
+	public List<AnswerResponseDto> updateAnswers(Long mapSongId, AnswerRequestDto requestDto, String authenticatedUserId) {
 		MapSong mapSong = mapSongRepository.findById(mapSongId)
 			.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다."));
+			
+		// 인증 검사
+		checkMapOwnership(mapSong.getMap(), authenticatedUserId);
 
 		// 기존 정답 삭제
 		answerRepository.deleteByMapSongId(mapSongId);
@@ -64,6 +78,4 @@ public class AnswerService {
 		answerRepository.saveAll(saved);
 		return saved.stream().map(AnswerResponseDto::new).toList();
 	}
-
-
 }

--- a/src/main/java/com/lshzzz/mato/service/HintService.java
+++ b/src/main/java/com/lshzzz/mato/service/HintService.java
@@ -1,5 +1,6 @@
 package com.lshzzz.mato.service;
 
+import com.lshzzz.mato.model.map.Map;
 import com.lshzzz.mato.model.mapsongs.MapSong;
 import com.lshzzz.mato.model.song.Hint;
 import com.lshzzz.mato.model.song.dto.HintDto;
@@ -18,11 +19,21 @@ import java.util.List;
 public class HintService {
 	private final HintRepository hintRepository;
 	private final MapSongRepository mapSongRepository;
+	
+	// 인증 검사 헬퍼 메서드
+	private void checkMapOwnership(Map map, String authenticatedUserId) {
+		if (!map.getUserId().equals(authenticatedUserId)) {
+			throw new IllegalArgumentException("맵에 대한 권한이 없습니다.");
+		}
+	}
 
 	@Transactional
-	public List<HintResponseDto> addHintsToMapSong(Long mapSongId, HintRequestDto requestDto) {
+	public List<HintResponseDto> addHintsToMapSong(Long mapSongId, HintRequestDto requestDto, String authenticatedUserId) {
 		MapSong mapSong = mapSongRepository.findById(mapSongId)
 			.orElseThrow(() -> new IllegalArgumentException("MapSong 없음"));
+			
+		// 인증 검사
+		checkMapOwnership(mapSong.getMap(), authenticatedUserId);
 
 		List<Hint> hints = requestDto.hints().stream()
 			.map(data -> Hint.builder()
@@ -46,9 +57,12 @@ public class HintService {
 	}
 
 	@Transactional
-	public List<HintResponseDto> updateHints(Long mapSongId, HintRequestDto requestDto) {
+	public List<HintResponseDto> updateHints(Long mapSongId, HintRequestDto requestDto, String authenticatedUserId) {
 		MapSong mapSong = mapSongRepository.findById(mapSongId)
 			.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다."));
+			
+		// 인증 검사
+		checkMapOwnership(mapSong.getMap(), authenticatedUserId);
 
 		// 기존 힌트 삭제
 		hintRepository.deleteByMapSongId(mapSongId);
@@ -65,5 +79,4 @@ public class HintService {
 		hintRepository.saveAll(saved);
 		return saved.stream().map(HintResponseDto::new).toList();
 	}
-
 }

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -30,6 +30,8 @@ public class MapService {
 			throw new IllegalArgumentException("맵 생성 권한이 없습니다.");
 		}
 
+		validateDuplicateMap(requestDto.name());
+
 		Map map = mapRepository.save(
 			Map.builder()
 				.userId(requestDto.userId())
@@ -41,7 +43,7 @@ public class MapService {
 
 		if (requestDto.songs() != null) {
 			for (MapSongRequestDto songReq : requestDto.songs()) {
-				handleSongRequest(map.getId(), songReq);
+				handleSongRequest(map.getId(), songReq, authenticatedUserId);
 			}
 		}
 
@@ -62,6 +64,20 @@ public class MapService {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
+	public List<MapResponseDto> getMapsByUserId(String userId) {
+		return mapRepository.findByUserId(userId).stream()
+			.map(this::buildMapResponseDto)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<MapResponseDto> getPublicMapsByUserId(String userId) {
+		return mapRepository.findByUserIdAndIsPublicTrue(userId).stream()
+			.map(this::buildMapResponseDto)
+			.toList();
+	}
+
 	@Transactional
 	public MapResponseDto updateMap(Long id, MapRequestDto requestDto, String authenticatedUserId) {
 		Map map = mapRepository.findById(id)
@@ -69,6 +85,10 @@ public class MapService {
 
 		if (!authenticatedUserId.equals(map.getUserId())) {
 			throw new IllegalArgumentException("맵 수정 권한이 없습니다.");
+		}
+
+		if (!map.getName().equals(requestDto.name())) {
+			validateDuplicateMap(requestDto.name());
 		}
 
 		map.update(requestDto.name(), requestDto.description(), requestDto.isPublic());
@@ -105,9 +125,9 @@ public class MapService {
 		return new MapResponseDto(map, mapSongDtos);
 	}
 
-	private void handleSongRequest(Long mapId, MapSongRequestDto songReq) {
+	private void handleSongRequest(Long mapId, MapSongRequestDto songReq, String authenticatedUserId) {
 		if (songReq.songId() != null) {
-			mapSongService.addSongToMap(mapId, songReq);
+			mapSongService.addSongToMap(mapId, songReq, authenticatedUserId);
 		} else if (songReq.newSong() != null) {
 			SongResponseDto createdSong = songService.createSong(songReq.newSong());
 			MapSongRequestDto linkDto = new MapSongRequestDto(
@@ -117,7 +137,7 @@ public class MapService {
 				songReq.endTime(),
 				songReq.repeatCount()
 			);
-			mapSongService.addSongToMap(mapId, linkDto);
+			mapSongService.addSongToMap(mapId, linkDto, authenticatedUserId);
 		}
 	}
 }

--- a/src/main/java/com/lshzzz/mato/service/MapService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapService.java
@@ -25,7 +25,11 @@ public class MapService {
 	private final MapSongService mapSongService;
 
 	@Transactional
-	public MapResponseDto createMap(MapRequestDto requestDto) {
+	public MapResponseDto createMap(MapRequestDto requestDto, String authenticatedUserId) {
+		if (!authenticatedUserId.equals(requestDto.userId())) {
+			throw new IllegalArgumentException("맵 생성 권한이 없습니다.");
+		}
+
 		Map map = mapRepository.save(
 			Map.builder()
 				.userId(requestDto.userId())
@@ -59,11 +63,11 @@ public class MapService {
 	}
 
 	@Transactional
-	public MapResponseDto updateMap(Long id, MapRequestDto requestDto) {
+	public MapResponseDto updateMap(Long id, MapRequestDto requestDto, String authenticatedUserId) {
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
 
-		if (!map.getUserId().equals(requestDto.userId())) {
+		if (!authenticatedUserId.equals(map.getUserId())) {
 			throw new IllegalArgumentException("맵 수정 권한이 없습니다.");
 		}
 
@@ -72,11 +76,11 @@ public class MapService {
 	}
 
 	@Transactional
-	public void deleteMap(Long id, Long userId) {
+	public void deleteMap(Long id, String authenticatedUserId) {
 		Map map = mapRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 맵이 존재하지 않습니다."));
 
-		if (!map.getUserId().equals(userId)) {
+		if (!authenticatedUserId.equals(map.getUserId())) {
 			throw new IllegalArgumentException("맵 삭제 권한이 없습니다.");
 		}
 

--- a/src/main/java/com/lshzzz/mato/service/MapSongService.java
+++ b/src/main/java/com/lshzzz/mato/service/MapSongService.java
@@ -30,10 +30,29 @@ public class MapSongService {
 	private final MapRepository mapRepository;
 	private final SongRepository songRepository;
 
+	// 인증 검사 헬퍼 메서드
+	private void checkMapOwnership(Map map, String authenticatedUserId) {
+		if (!map.getUserId().equals(authenticatedUserId)) {
+			throw new IllegalArgumentException("맵에 대한 권한이 없습니다.");
+		}
+	}
+	
+	// 맵의 소유권 확인
+	private void checkMapSongOwnership(Long mapSongId, String authenticatedUserId) {
+		MapSong mapSong = mapSongRepository.findById(mapSongId)
+			.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다."));
+			
+		Map map = mapSong.getMap();
+		checkMapOwnership(map, authenticatedUserId);
+	}
+
 	// 맵에 노래 추가
-	public MapSongResponseDto addSongToMap(Long mapId, MapSongRequestDto requestDto) {
+	public MapSongResponseDto addSongToMap(Long mapId, MapSongRequestDto requestDto, String authenticatedUserId) {
 		Map map = mapRepository.findById(mapId)
 			.orElseThrow(() -> new IllegalArgumentException("맵을 찾을 수 없습니다."));
+
+        // 인증 검사
+        checkMapOwnership(map, authenticatedUserId);
 
 		Song song = resolveSong(requestDto);
 		System.out.println("✅ song resolved: " + song.getId());
@@ -65,10 +84,13 @@ public class MapSongService {
 
 	// 노래 업데이트
 	@Transactional
-	public MapSongResponseDto updateMapSong(Long mapSongId, MapSongRequestDto requestDto) {
+	public MapSongResponseDto updateMapSong(Long mapSongId, MapSongRequestDto requestDto, String authenticatedUserId) {
 		try {
 			MapSong mapSong = mapSongRepository.findById(mapSongId)
 				.orElseThrow(() -> new IllegalArgumentException("MapSong을 찾을 수 없습니다. ID=" + mapSongId));
+				
+			// 인증 검사
+			checkMapOwnership(mapSong.getMap(), authenticatedUserId);
 
 			Song song = mapSong.getSong();
 
@@ -97,10 +119,10 @@ public class MapSongService {
 		}
 	}
 
-
-
 	// 노래 제거
-	public void removeSongFromMap(Long mapSongId) {
+	public void removeSongFromMap(Long mapSongId, String authenticatedUserId) {
+		// 인증 검사
+		checkMapSongOwnership(mapSongId, authenticatedUserId);
 		mapSongRepository.deleteById(mapSongId);
 	}
 
@@ -112,6 +134,7 @@ public class MapSongService {
 		} else if (requestDto.newSong() != null) {
 			return songRepository.save(Song.builder()
 				.youtubeUrl(requestDto.newSong().youtubeUrl())
+				.title(requestDto.newSong().title() != null ? requestDto.newSong().title() : "제목 없음")
 				.build());
 		}
 		throw new IllegalArgumentException("노래 정보가 제공되지 않았습니다.");
@@ -123,13 +146,13 @@ public class MapSongService {
 
 		List<AnswerDto> answers = mapSong.getAnswers().stream()
 			.filter(a -> a != null && a.getAnswerText() != null)
-			.map(a -> new AnswerDto(a.getId(), a.getId(), a.getAnswerText()))
+			.map(a -> new AnswerDto(a.getId(), mapSong.getId(), a.getAnswerText()))
 			.toList();
 
 
 		List<HintDto> hints = mapSong.getHints().stream()
 			.filter(h -> h != null && h.getHintText() != null)
-			.map(h -> new HintDto(h.getId(), h.getId(), h.getHintText(), h.getRevealTime()))
+			.map(h -> new HintDto(h.getId(), mapSong.getId(), h.getHintText(), h.getRevealTime()))
 			.toList();
 
 

--- a/src/main/java/com/lshzzz/mato/service/SongService.java
+++ b/src/main/java/com/lshzzz/mato/service/SongService.java
@@ -62,4 +62,19 @@ public class SongService {
 	public void deleteSong(Long id) {
 		songRepository.deleteById(id);
 	}
+
+	// URL로 노래 검색
+	@Transactional(readOnly = true)
+	public Optional<SongResponseDto> getSongByUrl(String youtubeUrl) {
+		return songRepository.findByYoutubeUrl(youtubeUrl)
+			.map(SongResponseDto::new);
+	}
+
+	// 제목으로 노래 검색 (부분 일치)
+	@Transactional(readOnly = true)
+	public List<SongResponseDto> searchSongsByTitle(String title) {
+		return songRepository.findByTitleContaining(title).stream()
+			.map(SongResponseDto::new)
+			.collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
### ✅ 주요 변경 사항
- 맵 생성/수정/삭제 시 인증된 사용자 정보(`@AuthenticationPrincipal`) 활용
- 정답/힌트/노래 수정 및 삭제 시 사용자 권한 검증 로직 추가
- 사용자별 맵 목록 조회 기능 추가 (내 맵 / 타인 공개 맵 구분)
- 맵 이름 중복 체크 로직 강화
- 노래 검색 기능 추가 (유튜브 URL, 제목 기반 검색)
- `userId` 관련 DTO 및 엔티티 타입 `String`으로 통일

### 🔒 인증 기반 권한 제어 적용 대상
- `MapService`, `MapSongService`, `AnswerService`, `HintService`
- `MapController`, `MapSongController`

### 🎵 노래 검색 API
- `GET /api/songs/search/url?youtubeUrl=...`
- `GET /api/songs/search/title?title=...`

### 관련 이슈
Closed #28 