### PR TITLE
Chore: 환경변수 기반 prod 설정 리팩토링

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# 1단계: 빌드 이미지
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /app
+
+# 프로젝트 의존성 캐싱을 위해 먼저 복사
+COPY build.gradle settings.gradle gradle.properties ./
+COPY gradle ./gradle
+RUN gradle --no-daemon build || return 0
+
+# 실제 코드 복사
+COPY . .
+
+# Spring Boot 애플리케이션 빌드
+RUN gradle clean bootJar --no-daemon
+
+# 2단계: 실행 이미지
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+# 빌드된 JAR 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# 프로덕션 프로파일 사용 (yml에서는 환경변수 기반 설정)
+ENV SPRING_PROFILES_ACTIVE=prod
+
+# 포트 노출
+EXPOSE 8080
+
+# 실행 명령
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,27 +1,31 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_HOST:localhost}:3306/mato?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
-    username: ${DB_USER:root}
-    password: ${DB_PASSWORD:root}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: update  # ?? ? update, ?? ? validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        format_sql: true
-        show_sql: true
 
   data:
     redis:
-      host: ${SPRING_DATA_REDIS_HOST}
-      port: ${SPRING_DATA_REDIS_PORT}
-      password: ${SPRING_DATA_REDIS_PASSWORD}
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true
 
   jwt:
-    secret-key: ${SPRING_JWT_SECRET_KEY}
+    secret-key: ${JWT_SECRET}
 
 server:
-  port: 8080
+  port: ${SERVER_PORT}
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
📌 개요  
기존의 application.yml에서 하드코딩된 데이터베이스, Redis, JWT, 서버 포트 설정을 제거하고,  
프로덕션 환경에 적합한 방식으로 환경변수 기반 설정으로 리팩토링했습니다.

✅ 변경 사항
- `${DB_HOST}`, `${DB_PORT}`, `${DB_NAME}`, `${DB_USERNAME}`, `${DB_PASSWORD}` 등으로 DB 연결 정보 분리
- `${REDIS_HOST}`, `${REDIS_PORT}`, `${REDIS_PASSWORD}`로 Redis 연결 정보 분리
- `${JWT_SECRET}` 및 `${SERVER_PORT}` 환경변수 사용
- Hibernate 로그 레벨 설정 추가 (`org.hibernate.SQL: debug`)
- `show-sql` 및 `format_sql` 적용으로 디버깅 편의성 강화

🎯 목적
- GitHub Actions 또는 Docker 환경에서 민감 정보를 안전하게 관리 가능
- 다양한 배포 환경 대응 (로컬/테스트/운영 등)
- Docker 및 CI/CD 연동을 위한 사전 작업
