### PR TITLE
Chore: Docker 기반 배포 환경 설정 리팩토링

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,13 @@ FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
 # 빌드된 JAR 파일 복사
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=build /app/build/libs/*.jar app.jar
 
 # 프로덕션 프로파일 사용 (yml에서는 환경변수 기반 설정)
 ENV SPRING_PROFILES_ACTIVE=prod
 
 # 포트 노출
-EXPOSE 8080
+EXPOSE 8081
 
 # 실행 명령
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,99 @@
+pipeline {
+    agent any
+
+    environment {
+        // 💻 Docker
+        DOCKER_IMAGE = 'matoapp-backend'
+        DOCKER_TAG = "${BUILD_NUMBER}"
+
+        // 🌐 공개 환경변수 (Jenkins Global Properties에 등록된 값)
+        DB_HOST = 'mysql'
+        DB_PORT = '3306'
+        DB_NAME = 'mato'
+        SERVER_PORT = '8081'
+        SPRING_PROFILES_ACTIVE = 'prod'
+        SPRING_DATA_REDIS_HOST = 'redis'
+        SPRING_DATA_REDIS_PORT = '6379'
+    }
+
+    stages {
+        stage('Load Secrets') {
+            steps {
+                withCredentials([
+                    usernamePassword(
+                        credentialsId: 'db-credentials',
+                        usernameVariable: 'DB_USERNAME',
+                        passwordVariable: 'DB_PASSWORD'
+                    ),
+                    string(credentialsId: 'redis-password', variable: 'SPRING_DATA_REDIS_PASSWORD'),
+                    string(credentialsId: 'jwt-secret', variable: 'JWT_SECRET')
+                ]) {
+                    echo "✅ 비밀 환경변수 로딩 완료"
+                }
+            }
+        }
+
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh './gradlew clean build -x test'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh './gradlew test'
+            }
+        }
+
+        stage('Docker Build') {
+            steps {
+                sh """
+                    docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+                    docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
+                """
+            }
+        }
+
+        stage('Deploy') {
+            steps {
+                sh """
+                    docker stop ${DOCKER_IMAGE} || true
+                    docker rm ${DOCKER_IMAGE} || true
+                    docker run -d \\
+                        --name ${DOCKER_IMAGE} \\
+                        -p ${SERVER_PORT}:${SERVER_PORT} \\
+                        -e DB_HOST=${DB_HOST} \\
+                        -e DB_PORT=${DB_PORT} \\
+                        -e DB_NAME=${DB_NAME} \\
+                        -e DB_USERNAME=${DB_USERNAME} \\
+                        -e DB_PASSWORD=${DB_PASSWORD} \\
+                        -e SPRING_DATA_REDIS_HOST=${SPRING_DATA_REDIS_HOST} \\
+                        -e SPRING_DATA_REDIS_PORT=${SPRING_DATA_REDIS_PORT} \\
+                        -e SPRING_DATA_REDIS_PASSWORD=${SPRING_DATA_REDIS_PASSWORD} \\
+                        -e SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE} \\
+                        -e JWT_SECRET=${JWT_SECRET} \\
+                        -e SERVER_PORT=${SERVER_PORT} \\
+                        ${DOCKER_IMAGE}:${DOCKER_TAG}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+        success {
+            echo '✅ 파이프라인이 성공적으로 완료되었습니다!'
+        }
+        failure {
+            echo '❌ 파이프라인 실패. 로그 확인 필요.'
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,58 @@
+version: '3.8'
+
 services:
-  backend:
+  app:
     build: .
+    container_name: matoapp-backend
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"
     environment:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
-      - DB_HOST=${DB_HOST}
-      - DB_PORT=${DB_PORT}
-      - DB_NAME=${DB_NAME}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - SPRING_DATASOURCE_URL=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+      - SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
       - SPRING_DATA_REDIS_HOST=${SPRING_DATA_REDIS_HOST}
       - SPRING_DATA_REDIS_PORT=${SPRING_DATA_REDIS_PORT}
       - SPRING_DATA_REDIS_PASSWORD=${SPRING_DATA_REDIS_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
+      - SERVER_PORT=${SERVER_PORT}
     depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_started
+      - mysql
+      - redis
+    networks:
+      - mato-network
+    restart: unless-stopped
 
-  db:
+  mysql:
     image: mysql:8.0
-    container_name: mysql-db
-    ports:
-      - "${DB_PORT}:${DB_PORT}"
+    container_name: mato-mysql
     environment:
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+    ports:
+      - "${DB_PORT}:3306"
     volumes:
-      - db_data:/var/lib/mysql
-    healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-p${DB_PASSWORD}" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      - mysql-data:/var/lib/mysql
+    networks:
+      - mato-network
+    restart: unless-stopped
 
   redis:
-    image: redis:7.0-alpine
-    container_name: redis-server
-    ports:
-      - "${SPRING_DATA_REDIS_PORT}:${SPRING_DATA_REDIS_PORT}"
+    image: redis:7.0
+    container_name: mato-redis
     command: redis-server --requirepass ${SPRING_DATA_REDIS_PASSWORD}
+    ports:
+      - "${SPRING_DATA_REDIS_PORT}:6379"
     volumes:
-      - redis_data:/data
+      - redis-data:/data
+    networks:
+      - mato-network
+    restart: unless-stopped
+
+networks:
+  mato-network:
+    driver: bridge
 
 volumes:
-  db_data:
-  redis_data:
+  mysql-data:
+  redis-data:


### PR DESCRIPTION
✅ 변경 사항
docker-compose.yml 구조 개선

서비스 이름 통일 (mato-mysql, mato-redis, matoapp-backend)

networks, volumes 명시적 구성 추가

depends_on 및 restart 정책 설정

Dockerfile 수정

멀티스테이지 빌드 적용 (builder, runtime)

프로덕션 환경에 맞춰 ENV SPRING_PROFILES_ACTIVE=prod 추가

포트 8081로 변경

application.yml에서 사용하는 환경변수 기반 실행을 위해 ENV 및 docker-compose environment 항목 구성

🧪 테스트
docker-compose up 실행 시 문제 없이 backend + db + redis 기동 확인

Jenkins 빌드와 연동을 위한 구조 테스트 완료 예정

📌 기타
Jenkins 파이프라인과 연동되는 구조 준비됨

.env 파일은 Jenkins 환경변수 또는 Secrets로 관리할 예정 (민감 정보는 포함하지 않음)