### PR TITLE
Chore: CORS 및 WebSocket 허용 도메인에 배포 서버 IP 추가

### DIFF
--- a/src/main/java/com/lshzzz/mato/config/SecurityConfig.java
+++ b/src/main/java/com/lshzzz/mato/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowedOrigins(List.of("http://localhost:5173"));
+        corsConfiguration.setAllowedOrigins(List.of("http://localhost:5173", "http://112.159.76.59:5173"));
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowCredentials(true); // 쿠키 등 자격 증명을 사용하는 경우

--- a/src/main/java/com/lshzzz/mato/config/WebSocketConfig.java
+++ b/src/main/java/com/lshzzz/mato/config/WebSocketConfig.java
@@ -19,7 +19,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws")
-			.setAllowedOrigins("http://localhost:3000", "http://localhost:8080", "http://localhost:5173") // 특정 도메인만 허용
+			.setAllowedOrigins("http://localhost:3000", "http://localhost:8080", "http://localhost:5173", "http://112.159.76.59:5173", "http://112.159.76.59:8081"
+			) // 특정 도메인만 허용
 			.withSockJS();
 	}
 


### PR DESCRIPTION
- CORS 설정에 http://112.159.76.59 추가
- WebSocket 엔드포인트에도 동일한 IP 허용 도메인으로 등록