### PR TITLE
Refactor: Redis 통합을 통한 참가자 관리 및 방 상태 처리 개선

### DIFF
--- a/src/main/java/com/lshzzz/mato/config/SecurityConfig.java
+++ b/src/main/java/com/lshzzz/mato/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowedOrigins(List.of("http://localhost:15173", "http://112.159.76.59:15173"));
+        corsConfiguration.setAllowedOrigins(List.of("http://localhost:5173", "http://112.159.76.59:15173"));
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowCredentials(true); // 쿠키 등 자격 증명을 사용하는 경우

--- a/src/main/java/com/lshzzz/mato/controller/rooms/GameWebSocketController.java
+++ b/src/main/java/com/lshzzz/mato/controller/rooms/GameWebSocketController.java
@@ -3,6 +3,7 @@ package com.lshzzz.mato.controller.rooms;
 import com.lshzzz.mato.model.chat.dto.ChatMessage;
 import com.lshzzz.mato.model.game.dto.GameStatusResponse;
 import com.lshzzz.mato.service.game.GameService;
+import com.lshzzz.mato.service.rooms.RedisRoomsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -10,22 +11,129 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
+import java.util.Set;
+import java.util.HashSet;
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class GameWebSocketController {
 	private final SimpMessagingTemplate messagingTemplate;
 	private final GameService gameService;
+	private final RedisRoomsService roomsService;
 
 	@MessageMapping("/chat.join")
 	public void handleJoin(@Payload ChatMessage message) {
-		String content = message.sender() + "님이 입장하셨습니다.";
-		ChatMessage joinMessage = new ChatMessage("SYSTEM", content, message.roomName(), "JOIN");
-		messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), joinMessage);
+		log.info("입장 메시지 수신: {} 사용자가 {} 방에 입장 시도", message.sender(), message.roomName());
+		
+		try {
+			// 이미 참가자인지 확인 (중복 참가 방지)
+			Set<String> participants = roomsService.getParticipants(message.roomName());
+			if (participants.contains(message.sender())) {
+				log.info("{} 사용자는 이미 {} 방에 참가 중입니다. 중복 입장 무시.", message.sender(), message.roomName());
+				// 이미 참가 중인 경우 입장 메시지 전송하지 않음
+				
+				// 하지만 클라이언트에게 최신 참가자 목록을 갱신하도록 알림은 보낸다
+				ChatMessage updateMessage = new ChatMessage("SYSTEM", "참가자 목록 갱신", message.roomName(), "UPDATE_PARTICIPANTS");
+				messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), updateMessage);
+				
+				// 로비에는 업데이트 메시지를 보내지 않음 (참가자 수 변경 없음)
+				return;
+			}
+			
+			// 새로운 참가자인 경우에만 정상 처리
+			log.info("{} 사용자를 {} 방의 참가자로 추가합니다.", message.sender(), message.roomName());
+			
+			// 입장 메시지 생성 및 전송
+			String content = message.sender() + "님이 입장하셨습니다.";
+			ChatMessage joinMessage = new ChatMessage("SYSTEM", content, message.roomName(), "JOIN");
+			messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), joinMessage);
+			
+			// 로비에도 방 업데이트 메시지 전송 (참가자 수 변경됨)
+			ChatMessage lobbyUpdateMessage = new ChatMessage("SYSTEM", message.roomName(), "LOBBY", "PARTICIPANT_CHANGE");
+			messagingTemplate.convertAndSend("/topic/lobby", lobbyUpdateMessage);
+		} catch (Exception e) {
+			log.error("입장 처리 중 오류 발생", e);
+		}
 	}
 
 	@MessageMapping("/chat.leave")
 	public void handleLeave(@Payload ChatMessage message) {
+		log.info("퇴장 메시지 수신: {} 사용자가 {} 방에서 퇴장", message.sender(), message.roomName());
+		
+		// 참가자 목록에서 제거 요청 (별도 HTTP 요청도 있지만 추가 안전장치)
+		try {
+			// 제거 전에 남은 참가자 수를 확인 (지금 퇴장하는 참가자 포함)
+			Set<String> participants = roomsService.getParticipants(message.roomName());
+			int participantsCount = participants.size();
+			log.info("퇴장 전 {} 방 참가자 수: {}", message.roomName(), participantsCount);
+			
+			// 이미 참가자가 HTTP 요청으로 제거되었을 수 있으므로 다시 확인
+			boolean isStillParticipant = participants.contains(message.sender());
+			
+			// 아직 참가자인 경우에만 제거 처리
+			if (isStillParticipant) {
+				// 참가자 제거 처리 (이 메서드 내에서 0명일 경우 방 삭제 로직 포함)
+				log.info("{} 사용자를 {} 방에서 제거합니다(웹소켓 요청)", message.sender(), message.roomName());
+				roomsService.removeParticipant(message.roomName(), message.sender());
+			} else {
+				log.info("{} 사용자는 이미 {} 방에서 제거되어 있습니다", message.sender(), message.roomName());
+			}
+			
+			// 퇴장 후 남은 참가자 수 확인
+			Set<String> remainingParticipants;
+			try {
+				remainingParticipants = roomsService.getParticipants(message.roomName());
+				int remainingCount = remainingParticipants.size();
+				log.info("퇴장 후 {} 방 남은 참가자 수: {}", message.roomName(), remainingCount);
+				
+				// 남은 참가자가 0명이면 방 삭제
+				if (remainingCount == 0) {
+					log.info("방 {}에 참가자가 없으므로 방을 삭제합니다.", message.roomName());
+					try {
+						roomsService.deleteRoomByName(message.roomName());
+						log.info("방 {} 삭제 성공", message.roomName());
+					} catch (Exception e) {
+						log.info("방 {}이 이미 삭제되었습니다.", message.roomName());
+					}
+				} else if (remainingCount == 1) {
+					log.info("방 {} 남은 참가자가 1명 남았습니다.", message.roomName());
+				}
+			} catch (Exception e) {
+				// 방이 이미 삭제된 경우 발생할 수 있는 예외를 처리
+				log.info("방 {}이 이미 삭제되었습니다", message.roomName());
+				remainingParticipants = new HashSet<>();
+			}
+			
+			// 이벤트 타입을 동적으로 결정
+			String eventType = remainingParticipants.isEmpty() ? "ROOM_DELETE" : "PARTICIPANT_CHANGE";
+			
+			// 로비에 방 업데이트 메시지 전송 (참가자 수 변경 또는 방 삭제)
+			ChatMessage lobbyUpdateMessage = new ChatMessage(
+				"SYSTEM", 
+				message.roomName(), 
+				"LOBBY", 
+				eventType
+			);
+			messagingTemplate.convertAndSend("/topic/lobby", lobbyUpdateMessage);
+			log.info("로비에 {} 이벤트를 전송했습니다", eventType);
+			
+			// 남은 참가자들에게 업데이트된 참가자 목록을 보내도록 추가 메시지 전송
+			if (!remainingParticipants.isEmpty()) {
+				ChatMessage roomUpdateMessage = new ChatMessage(
+					"SYSTEM", 
+					"참가자 목록이 업데이트되었습니다", 
+					message.roomName(), 
+					"UPDATE_PARTICIPANTS"
+				);
+				messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), roomUpdateMessage);
+				log.info("방 {}에 참가자 목록 업데이트 메시지를 전송했습니다", message.roomName());
+			}
+		} catch (Exception e) {
+			log.error("퇴장 처리 중 오류 발생", e);
+		}
+		
+		// 퇴장 메시지 전송
 		String content = message.sender() + "님이 퇴장하셨습니다.";
 		ChatMessage leaveMessage = new ChatMessage("SYSTEM", content, message.roomName(), "LEAVE");
 		messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), leaveMessage);
@@ -40,11 +148,19 @@ public class GameWebSocketController {
 	public void handleGameStart(@Payload ChatMessage message) {
 		gameService.startGame(message.roomName());
 		// 중복 브로드캐스트 제거 (GameService에서 GameStatusResponse 전송함)
+		
+		// 로비에도 방 상태 업데이트 메시지 전송 (게임 시작됨)
+		ChatMessage lobbyUpdateMessage = new ChatMessage("SYSTEM", message.roomName(), "LOBBY", "ROOM_UPDATE");
+		messagingTemplate.convertAndSend("/topic/lobby", lobbyUpdateMessage);
 	}
 
 	@MessageMapping("/game.end")
 	public void handleGameEnd(@Payload ChatMessage message) {
 		gameService.endGame(message.roomName());
+		
+		// 로비에도 방 상태 업데이트 메시지 전송 (게임 종료됨)
+		ChatMessage lobbyUpdateMessage = new ChatMessage("SYSTEM", message.roomName(), "LOBBY", "ROOM_UPDATE");
+		messagingTemplate.convertAndSend("/topic/lobby", lobbyUpdateMessage);
 	}
 
 	@MessageMapping("/game.next")
@@ -84,5 +200,44 @@ public class GameWebSocketController {
 	public void getGameStatus(@Payload ChatMessage message) {
 		GameStatusResponse status = gameService.getGameStatus(message.roomName());
 		messagingTemplate.convertAndSend("/topic/rooms/" + message.roomName(), status);
+	}
+
+	// 로비 강제 갱신 요청 처리
+	@MessageMapping("/lobby.update")
+	public void handleLobbyUpdate(@Payload ChatMessage message) {
+		log.info("로비 강제 갱신 요청 수신: 타입={}, 내용={}", message.type(), message.content());
+		
+		// 메시지 타입에 따라 다른 처리
+		if ("PARTICIPANT_LEAVE".equals(message.type())) {
+			// 참가자 퇴장 처리 - 바로 로비에 반영
+			String[] parts = message.content().split("\\|");
+			String leavingUser = parts.length > 0 ? parts[0] : "unknown";
+			int remainingCount = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+			
+			log.info("참가자 {} 퇴장 처리, 남은 인원: {}", leavingUser, remainingCount);
+			
+			// 참가자 변경 메시지 전송
+			ChatMessage participantChangeMsg = new ChatMessage(
+				"SYSTEM",
+				message.roomName() + "|" + remainingCount, // 방 이름과 남은 인원 수 전달
+				"LOBBY",
+				"PARTICIPANT_CHANGE"
+			);
+			messagingTemplate.convertAndSend("/topic/lobby", participantChangeMsg);
+			log.info("로비에 참가자 변경 메시지를 전송했습니다: 방={}, 남은 인원={}", 
+				message.roomName(), remainingCount);
+			
+			return;
+		}
+		
+		// 기본적인 강제 갱신 메시지
+		ChatMessage forceRefreshMessage = new ChatMessage(
+			"SYSTEM",
+			message.content(),
+			"LOBBY",
+			message.type().equals("FORCE_REFRESH") ? "FORCE_REFRESH" : "ROOM_UPDATE"
+		);
+		messagingTemplate.convertAndSend("/topic/lobby", forceRefreshMessage);
+		log.info("로비 강제 갱신 메시지를 전송했습니다");
 	}
 }

--- a/src/main/java/com/lshzzz/mato/controller/rooms/RoomsController.java
+++ b/src/main/java/com/lshzzz/mato/controller/rooms/RoomsController.java
@@ -1,5 +1,6 @@
 package com.lshzzz.mato.controller.rooms;
 
+import com.lshzzz.mato.model.chat.dto.ChatMessage;
 import com.lshzzz.mato.model.room.dto.ParticipantReadyRequest;
 import com.lshzzz.mato.model.room.dto.RoomPasswordValidationRequest;
 import com.lshzzz.mato.model.room.dto.RoomsCreateRequest;
@@ -11,10 +12,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -23,6 +27,7 @@ import java.util.HashMap;
 public class RoomsController {
 
     private final RoomsService roomsService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     // 전체 방 조회
     @GetMapping
@@ -49,7 +54,20 @@ public class RoomsController {
     @PostMapping("/{name}/participants")
     public ResponseEntity<Void> addParticipant(@PathVariable String name, HttpServletRequest request) {
         String nickname = roomsService.resolveNickname(request);
+        
+        // 이미 참가자인지 확인
+        Set<String> participants = roomsService.getParticipants(name);
+        if (participants.contains(nickname)) {
+            log.info("이미 방에 참가 중인 사용자입니다: {}, 방: {}. 추가 요청 무시.", nickname, name);
+            return ResponseEntity.ok().build(); // 이미 참가 중이면 OK 반환하고 종료
+        }
+        
+        log.info("새 참가자 추가: {}, 방: {}", nickname, name);
         roomsService.addParticipant(name, nickname);
+        
+        // 로비에 참가자 변경 알림
+        sendLobbyUpdateMessage(name, "PARTICIPANT_CHANGE");
+        
         return ResponseEntity.ok().build();
     }
 
@@ -58,6 +76,10 @@ public class RoomsController {
     public ResponseEntity<Void> removeParticipant(@PathVariable String name, HttpServletRequest request) {
         String nickname = roomsService.resolveNickname(request);
         roomsService.removeParticipant(name, nickname);
+        
+        // 로비에 참가자 변경 알림
+        sendLobbyUpdateMessage(name, "PARTICIPANT_CHANGE");
+        
         return ResponseEntity.ok().build();
     }
 
@@ -76,7 +98,12 @@ public class RoomsController {
     public ResponseEntity<RoomsResponse> createRoom(@RequestBody @Valid RoomsCreateRequest request,
         HttpServletRequest httpRequest) {
         String hostNickname = roomsService.resolveNickname(httpRequest);
-        return ResponseEntity.ok(roomsService.createRoom(request, hostNickname));
+        RoomsResponse response = roomsService.createRoom(request, hostNickname);
+        
+        // 로비에 방 생성 알림
+        sendLobbyUpdateMessage(request.name(), "ROOM_CREATE");
+        
+        return ResponseEntity.ok(response);
     }
 
     // 방 수정
@@ -85,7 +112,12 @@ public class RoomsController {
         @RequestBody @Valid RoomsUpdateRequest request,
         HttpServletRequest httpRequest) {
         String nickname = roomsService.resolveNickname(httpRequest);
-        return ResponseEntity.ok(roomsService.updateRoom(id, request, nickname));
+        RoomsResponse response = roomsService.updateRoom(id, request, nickname);
+        
+        // 로비에 방 정보 업데이트 알림
+        sendLobbyUpdateMessage(response.name(), "ROOM_UPDATE");
+        
+        return ResponseEntity.ok(response);
     }
 
     // 방 삭제
@@ -93,7 +125,13 @@ public class RoomsController {
     public ResponseEntity<Void> deleteRoom(@PathVariable Long id,
         HttpServletRequest httpRequest) {
         String nickname = roomsService.resolveNickname(httpRequest);
+        
+        // 방 이름 객체를 미리 알 수 없으므로, 삭제 후 로그만 남김
         roomsService.deleteRoom(id, nickname);
+        
+        // 로비에 방 삭제 알림 (방 이름 대신 id 문자열 사용)
+        sendLobbyUpdateMessage("room_" + id, "ROOM_DELETE");
+        
         return ResponseEntity.noContent().build();
     }
 
@@ -103,6 +141,64 @@ public class RoomsController {
         @RequestBody RoomPasswordValidationRequest request) {
         boolean result = roomsService.validatePassword(request.name(), request.password());
         return ResponseEntity.ok(result);
+    }
+    
+    // 로비에 방 업데이트 메시지 전송하는 유틸리티 메서드
+    private void sendLobbyUpdateMessage(String roomName, String type) {
+        try {
+            ChatMessage lobbyUpdateMessage = new ChatMessage("SYSTEM", roomName, "LOBBY", type);
+            messagingTemplate.convertAndSend("/topic/lobby", lobbyUpdateMessage);
+            log.info("로비에 {} 이벤트 전송 완료: 방 {}", type, roomName);
+        } catch (Exception e) {
+            log.error("로비 메시지 전송 중 오류 발생", e);
+        }
+    }
+
+    // 로비 강제 갱신 요청 (클라이언트에서 호출)
+    @PostMapping("/notify-lobby-update")
+    public ResponseEntity<Void> notifyLobbyUpdate(@RequestBody Map<String, String> request) {
+        String type = request.getOrDefault("type", "FORCE_REFRESH");
+        String roomName = request.getOrDefault("roomName", "unknown");
+        
+        // WebSocket을 통해 로비에 메시지 전송
+        log.info("로비 강제 갱신 HTTP 요청 수신: 타입={}, 방={}", type, roomName);
+        
+        sendLobbyUpdateMessage(roomName, type);
+        
+        return ResponseEntity.ok().build();
+    }
+
+    // 게스트 사용자 일괄 제거 엔드포인트 
+    @DeleteMapping("/{name}/guests")
+    public ResponseEntity<Map<String, Object>> removeGuestUsers(@PathVariable String name) {
+        log.info("방 {} 게스트 사용자 일괄 제거 요청", name);
+        
+        try {
+            // 게스트로 시작하는 닉네임을 가진 참가자들 제거
+            roomsService.cleanupParticipantsByPattern(name, "게스트");
+            
+            // 남은 참가자 목록 조회
+            List<HashMap<String, Object>> remainingParticipants = roomsService.getRoomParticipants(name);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("message", "게스트 사용자가 성공적으로 제거되었습니다.");
+            response.put("remainingParticipantsCount", remainingParticipants.size());
+            
+            log.info("방 {} 게스트 사용자 제거 완료, 남은 참가자: {}명", name, remainingParticipants.size());
+            
+            // 로비 업데이트 메시지 전송
+            sendLobbyUpdateMessage(name, "PARTICIPANT_CHANGE");
+            
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("게스트 사용자 제거 중 오류 발생: {}", e.getMessage(), e);
+            
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("error", "게스트 사용자 제거 중 오류가 발생했습니다.");
+            errorResponse.put("message", e.getMessage());
+            
+            return ResponseEntity.status(500).body(errorResponse);
+        }
     }
 
     // 아래 메서드들은 API v2에서 사용될 예정입니다.

--- a/src/main/java/com/lshzzz/mato/repository/redis/RedisRoomsRepository.java
+++ b/src/main/java/com/lshzzz/mato/repository/redis/RedisRoomsRepository.java
@@ -141,8 +141,24 @@ public class RedisRoomsRepository {
         String participantsKey = ROOMS_PREFIX + roomName + ":participants";
         String readyKey = ROOMS_PREFIX + roomName + ":ready";
         
-        redisTemplate.opsForSet().remove(participantsKey, nickname);
-        redisTemplate.opsForHash().delete(readyKey, nickname);
+        // 제거 전에 해당 사용자가 참가자인지 확인
+        boolean isMember = Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(participantsKey, nickname));
+        
+        if (isMember) {
+            // 참가자 집합에서 제거
+            Long removeResult = redisTemplate.opsForSet().remove(participantsKey, nickname);
+            // 준비 상태에서 제거
+            Long deleteResult = redisTemplate.opsForHash().delete(readyKey, nickname);
+            
+            log.info("참가자 {} 제거 결과: 참가자 집합={}, 준비 상태={}", 
+                    nickname, removeResult, deleteResult);
+        } else {
+            log.info("참가자 {} 제거 실패: 이미 참가자 목록에 없음 (방: {})", nickname, roomName);
+        }
+        
+        // 제거 후 남은 참가자 수 확인
+        Long size = redisTemplate.opsForSet().size(participantsKey);
+        log.info("방 {} 참가자 제거 후 남은 참가자 수: {}", roomName, size);
     }
 
     /**

--- a/src/main/java/com/lshzzz/mato/service/rooms/RedisRoomsService.java
+++ b/src/main/java/com/lshzzz/mato/service/rooms/RedisRoomsService.java
@@ -200,6 +200,19 @@ public class RedisRoomsService {
         redisRoomsRepository.deleteByName(room.name());
     }
 
+    // 방 이름으로 방 삭제
+    @Transactional
+    public void deleteRoomByName(String roomName) {
+        // 방 존재 확인
+        redisRoomsRepository.findByName(roomName)
+            .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+        
+        // Redis에서 방 삭제
+        log.info("방 이름으로 방 삭제 요청: {}", roomName);
+        redisRoomsRepository.deleteByName(roomName);
+        log.info("방 이름으로 방 삭제 성공: {}", roomName);
+    }
+
     // 비밀번호 검증
     public boolean validatePassword(String roomName, String inputPassword) {
         RoomDto room = redisRoomsRepository.findByName(roomName)
@@ -219,25 +232,127 @@ public class RedisRoomsService {
         RoomDto room = redisRoomsRepository.findByName(roomName)
             .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
         
-        // 참가자 수 제한 확인
+        // 이미 참가자로 등록되어 있는지 확인
         Set<String> participants = redisRoomsRepository.getParticipants(roomName);
+        if (participants.contains(nickname)) {
+            log.info("이미 방에 참가 중인 사용자입니다: {}, 방: {}", nickname, roomName);
+            return; // 이미 참가 중이면 중복 추가하지 않고 조용히 반환
+        }
+        
+        // 참가자 수 제한 확인
         if (participants.size() >= room.maxParticipants()) {
             throw new CustomException(ErrorCode.ROOM_FULL);
         }
         
         // 참가자 추가
         redisRoomsRepository.addParticipant(roomName, nickname);
+        log.info("참가자 추가 성공: {}, 방: {}", nickname, roomName);
+    }
+
+    // 특정 패턴의 닉네임을 가진 참가자들을 일괄 제거 (예: 게스트 사용자)
+    @Transactional
+    public void cleanupParticipantsByPattern(String roomName, String nicknamePattern) {
+        try {
+            // 방 존재 확인
+            RoomDto room = redisRoomsRepository.findByName(roomName)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+            
+            // 현재 참가자 목록 가져오기
+            Set<String> participants = redisRoomsRepository.getParticipants(roomName);
+            log.info("방 {} 청소 전 참가자 수: {}", roomName, participants.size());
+            
+            // 패턴에 맞는 참가자들 필터링
+            List<String> participantsToRemove = participants.stream()
+                .filter(nickname -> nickname.startsWith(nicknamePattern))
+                .collect(Collectors.toList());
+            
+            log.info("방 {}에서 제거할 '{}' 패턴 참가자 수: {}", roomName, nicknamePattern, participantsToRemove.size());
+            
+            // 필터링된 참가자들 제거
+            int removedCount = 0;
+            for (String nickname : participantsToRemove) {
+                redisRoomsRepository.removeParticipant(roomName, nickname);
+                log.info("패턴 일치 참가자 제거: {} (방: {})", nickname, roomName);
+                removedCount++;
+            }
+            
+            log.info("방 {}에서 총 {}명의 {}* 패턴 참가자 제거 완료", roomName, removedCount, nicknamePattern);
+            
+            // 남은 참가자 확인
+            Set<String> remainingParticipants = redisRoomsRepository.getParticipants(roomName);
+            log.info("방 {} 청소 후 남은 참가자 수: {}", roomName, remainingParticipants.size());
+            
+            // 참가자가 모두 나갔으면 방 삭제
+            if (remainingParticipants.isEmpty()) {
+                log.info("방 {}의 참가자가 모두 제거되어 방을 자동 삭제합니다", roomName);
+                redisRoomsRepository.deleteByName(roomName);
+            }
+            
+        } catch (Exception e) {
+            log.error("참가자 패턴 일괄 제거 중 오류 발생: {}", e.getMessage(), e);
+        }
     }
 
     // 참가자 제거
     @Transactional
     public void removeParticipant(String roomName, String nickname) {
-        // 방 존재 확인
-        redisRoomsRepository.findByName(roomName)
-            .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
-        
-        // 참가자 제거
-        redisRoomsRepository.removeParticipant(roomName, nickname);
+        try {
+            // 방 존재 확인
+            RoomDto room = redisRoomsRepository.findByName(roomName)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+            
+            // 이미 참가자 목록에 존재하는지 확인
+            Set<String> participants = redisRoomsRepository.getParticipants(roomName);
+            if (!participants.contains(nickname)) {
+                log.info("참가자 제거 건너뜀: {} 사용자는 {} 방의 참가자가 아닙니다", nickname, roomName);
+                return;
+            }
+            
+            // 참가자 제거
+            log.info("참가자 제거 시작: {} (방: {})", nickname, roomName);
+            redisRoomsRepository.removeParticipant(roomName, nickname);
+            log.info("참가자 제거 완료: {} (방: {})", nickname, roomName);
+            
+            // 참가자 제거 후 남은 참가자 수 확인 (Redis에서 직접 조회하여 정확히 확인)
+            Set<String> remainingParticipants = redisRoomsRepository.getParticipants(roomName);
+            int participantCount = remainingParticipants.size();
+            log.info("방 {} 남은 참가자 수: {}", roomName, participantCount);
+            
+            // 참가자가 모두 나가면 방 삭제
+            if (participantCount == 0) {
+                log.info("방 {} 참가자가 모두 나갔으므로 방을 자동 삭제합니다.", roomName);
+                try {
+                    redisRoomsRepository.deleteByName(roomName);
+                    log.info("방 {} 삭제 완료", roomName);
+                } catch (Exception e) {
+                    log.error("방 삭제 중 오류: {}", e.getMessage());
+                }
+                
+                // 마지막 참가자 퇴장으로 방이 삭제되었다는 로그 추가
+                log.info("마지막 참가자 {} 퇴장으로 방 {} 자동 삭제됨", nickname, roomName);
+            } else if (room.host().equals(nickname)) {
+                // 방장이 나간 경우 새 방장 설정
+                String newHost = remainingParticipants.iterator().next(); // 첫 번째 참가자를 새 방장으로
+                log.info("방장 {} 퇴장으로 새 방장 설정: {} (방: {})", nickname, newHost, roomName);
+                
+                // 방장 정보 업데이트
+                RoomDto updatedRoom = new RoomDto(
+                    room.id(),
+                    room.name(),
+                    room.password(),
+                    room.maxParticipants(),
+                    newHost,
+                    room.gameStatus(),
+                    room.mapId()
+                );
+                redisRoomsRepository.save(updatedRoom);
+                log.info("새 방장 정보 저장 완료: {} (방: {})", newHost, roomName);
+            }
+        } catch (Exception e) {
+            // 방이 이미 삭제되었거나 기타 오류가 발생한 경우
+            log.error("참가자 제거 중 오류 발생: {}", e.getMessage());
+            // 오류가 발생해도 작업은 계속 진행 - 사용자는 방을 나갈 수 있어야 함
+        }
     }
 
     // 참가자 준비 상태 변경
@@ -321,5 +436,15 @@ public class RedisRoomsService {
             .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
         
         return mapToRoomListDto(roomDto);
+    }
+
+    // 참가자 목록 가져오기
+    public Set<String> getParticipants(String roomName) {
+        // 방 존재 확인
+        redisRoomsRepository.findByName(roomName)
+            .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+        
+        // 저장소에서 참가자 목록 조회하여 반환
+        return redisRoomsRepository.getParticipants(roomName);
     }
 } 

--- a/src/main/java/com/lshzzz/mato/service/rooms/RoomsService.java
+++ b/src/main/java/com/lshzzz/mato/service/rooms/RoomsService.java
@@ -88,4 +88,20 @@ public class RoomsService {
     public void setParticipantReady(String roomName, String nickname, boolean ready) {
         redisRoomsService.setParticipantReady(roomName, nickname, ready);
     }
+
+    // 방 참가자 목록 조회
+    public Set<String> getParticipants(String roomName) {
+        return redisRoomsService.getParticipants(roomName);
+    }
+
+    @Transactional
+    public void cleanupParticipantsByPattern(String roomName, String nicknamePattern) {
+        redisRoomsService.cleanupParticipantsByPattern(roomName, nicknamePattern);
+    }
+
+    // 방 이름으로 방 삭제
+    @Transactional
+    public void deleteRoomByName(String roomName) {
+        redisRoomsService.deleteRoomByName(roomName);
+    }
 }


### PR DESCRIPTION
- Redis를 활용하여 참가자 및 방 상태 관리 방식을 개선
- 방 생성, 수정, 삭제 및 참가자 관련 기능을 Redis 기반으로 리팩토링
- 참가자 목록 관리 및 준비 상태 처리를 Redis로 처리하도록 개선
- 기존 JPA 기반 방 서비스는 deprecated 처리, Redis 기반 서비스로 전환
- 방 및 참가자 관련 기능 성능 개선을 위해 Redis 사용
- `deleteRoomByName`, `getParticipants`, `cleanupParticipantsByPattern` 메서드 추가
- 기존 코드에서 Redis 통합과 관련된 주요 리팩토링 작업 수행

Closed #35 