### PR TITLE
ci: publish backend images with GitHub Actions

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -2,6 +2,9 @@ SPRING_PROFILES_ACTIVE=prod
 SERVER_PORT=18080
 COMPOSE_PROJECT_NAME=mato-prod
 
+# Prefer the immutable sha-<40-character-commit> tag in production.
+MATO_BACKEND_IMAGE=ghcr.io/ssquaredcoders/mato-backend:develop
+
 DB_NAME=mato
 DB_USERNAME=root
 DB_PASSWORD=replace-with-a-strong-database-password

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,110 @@
+name: Backend CI and image
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/develop' }}
+
+env:
+  IMAGE_NAME: ghcr.io/ssquaredcoders/mato-backend
+
+jobs:
+  test:
+    name: Test (Java 21)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/develop' }}
+          validate-wrappers: true
+
+      - name: Run tests
+        run: |
+          chmod +x gradlew
+          ./gradlew test --no-daemon --stacktrace
+
+  publish:
+    name: Publish GHCR image
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+    needs: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=develop
+          labels: |
+            org.opencontainers.image.title=MATO Backend
+            org.opencontainers.image.description=MATO Spring Boot backend
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=mato-backend
+          cache-to: type=gha,mode=max,scope=mato-backend
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest published image
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - develop
   workflow_dispatch:
 
 permissions:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,6 @@
 services:
   app:
-    build: .
-    image: mato-backend:latest
+    image: ${MATO_BACKEND_IMAGE:-ghcr.io/ssquaredcoders/mato-backend:develop}
     container_name: matoapp-backend
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- run Java 21 tests on GitHub-hosted runners
- publish signed, SBOM-enabled backend images to GHCR from develop
- switch production Compose from local builds to registry images
- validate the Gradle distribution checksum

## Validation
- gradlew test --no-daemon
- actionlint
- git diff --check