### PR TITLE
feat: extend sliding login session to 30 days

### DIFF
--- a/src/main/java/com/lshzzz/mato/controller/users/UsersController.java
+++ b/src/main/java/com/lshzzz/mato/controller/users/UsersController.java
@@ -12,6 +12,7 @@ import com.lshzzz.mato.model.users.dto.UsersUpdateRequest;
 import com.lshzzz.mato.model.users.dto.UsersUpdateResponse;
 import com.lshzzz.mato.service.users.RefreshTokenService;
 import com.lshzzz.mato.service.users.UsersService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
 import com.lshzzz.mato.utils.users.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -47,21 +48,25 @@ public class UsersController {
         UsersLoginResponse loginResponse = usersService.login(request.userId(), request.password());
 
         String accessToken = jwtUtil.createJwt(
-            "access",
+            AuthTokenPolicy.ACCESS_CATEGORY,
             loginResponse.userId(),
             loginResponse.nickname(),
             loginResponse.role().name(),
-            600000L
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
         );
         String refreshToken = jwtUtil.createJwt(
-            "refresh",
+            AuthTokenPolicy.REFRESH_CATEGORY,
             loginResponse.userId(),
             loginResponse.nickname(),
             loginResponse.role().name(),
-            86400000L
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
         );
 
-        refreshTokenService.saveRefreshToken(loginResponse.userId(), refreshToken, 86400L);
+        refreshTokenService.saveRefreshToken(
+            loginResponse.userId(),
+            refreshToken,
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
         response.setHeader("Authorization", "Bearer " + accessToken);
 
         return ResponseEntity.ok(loginResponse);

--- a/src/main/java/com/lshzzz/mato/service/users/RefreshTokenService.java
+++ b/src/main/java/com/lshzzz/mato/service/users/RefreshTokenService.java
@@ -1,25 +1,44 @@
 package com.lshzzz.mato.service.users;
 
+import java.time.Duration;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class RefreshTokenService {
 
     private final StringRedisTemplate redisTemplate;
-    private final ConcurrentMap<String, String> localFallback = new ConcurrentHashMap<>();
+    private final Clock clock;
+    private final ConcurrentMap<String, LocalRefreshToken> localFallback =
+        new ConcurrentHashMap<>();
 
-    public void saveRefreshToken(String username, String refreshToken, long duration) {
+    @Autowired
+    public RefreshTokenService(StringRedisTemplate redisTemplate) {
+        this(redisTemplate, Clock.systemUTC());
+    }
+
+    RefreshTokenService(StringRedisTemplate redisTemplate, Clock clock) {
+        this.redisTemplate = redisTemplate;
+        this.clock = clock;
+    }
+
+    public void saveRefreshToken(String username, String refreshToken, Duration ttl) {
+        requirePositiveTtl(ttl);
         String key = key(username);
         try {
-            redisTemplate.opsForValue().set(key, refreshToken, duration, TimeUnit.SECONDS);
+            redisTemplate.opsForValue().set(key, refreshToken, ttl);
+            localFallback.remove(key);
         } catch (Exception exception) {
-            localFallback.put(key, refreshToken);
+            localFallback.put(
+                key,
+                new LocalRefreshToken(refreshToken, clock.instant().plus(ttl))
+            );
         }
     }
 
@@ -27,9 +46,9 @@ public class RefreshTokenService {
         String key = key(username);
         try {
             String token = redisTemplate.opsForValue().get(key);
-            return token != null ? token : localFallback.get(key);
+            return token != null ? token : getLocalRefreshToken(key);
         } catch (Exception exception) {
-            return localFallback.get(key);
+            return getLocalRefreshToken(key);
         }
     }
 
@@ -45,5 +64,27 @@ public class RefreshTokenService {
 
     private String key(String username) {
         return "refresh:" + username;
+    }
+
+    private String getLocalRefreshToken(String key) {
+        LocalRefreshToken token = localFallback.get(key);
+        if (token == null) {
+            return null;
+        }
+        if (!token.expiresAt().isAfter(clock.instant())) {
+            localFallback.remove(key, token);
+            return null;
+        }
+        return token.value();
+    }
+
+    private void requirePositiveTtl(Duration ttl) {
+        Objects.requireNonNull(ttl, "ttl must not be null");
+        if (ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("ttl must be positive");
+        }
+    }
+
+    private record LocalRefreshToken(String value, Instant expiresAt) {
     }
 }

--- a/src/main/java/com/lshzzz/mato/utils/users/AuthTokenPolicy.java
+++ b/src/main/java/com/lshzzz/mato/utils/users/AuthTokenPolicy.java
@@ -1,0 +1,17 @@
+package com.lshzzz.mato.utils.users;
+
+import java.time.Duration;
+
+/**
+ * Shared lifetime and category policy for authentication tokens.
+ */
+public final class AuthTokenPolicy {
+
+    public static final String ACCESS_CATEGORY = "access";
+    public static final String REFRESH_CATEGORY = "refresh";
+    public static final Duration ACCESS_TOKEN_TTL = Duration.ofMinutes(10);
+    public static final Duration REFRESH_TOKEN_TTL = Duration.ofDays(30);
+
+    private AuthTokenPolicy() {
+    }
+}

--- a/src/main/java/com/lshzzz/mato/utils/users/JwtUtil.java
+++ b/src/main/java/com/lshzzz/mato/utils/users/JwtUtil.java
@@ -3,7 +3,10 @@ package com.lshzzz.mato.utils.users;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
+import java.util.Objects;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,8 +43,12 @@ public class JwtUtil {
     }
 
     public Boolean isExpired(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-            .getExpiration().before(new Date());
+        try {
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .getExpiration().before(new Date());
+        } catch (ExpiredJwtException exception) {
+            return true;
+        }
     }
 
     public String createJwt(
@@ -49,21 +56,24 @@ public class JwtUtil {
         String username,
         String nickname,
         String role,
-        Long expiredMs
+        Duration ttl
     ) {
+        requirePositiveTtl(ttl);
+        Instant issuedAt = Instant.now();
+
         return Jwts.builder()
             .claim("category", category)
             .claim("username", username)
             .claim("nickname", nickname)
             .claim("role", role)
-            .issuedAt(new Date(System.currentTimeMillis()))
-            .expiration(new Date(System.currentTimeMillis() + expiredMs))
+            .issuedAt(Date.from(issuedAt))
+            .expiration(Date.from(issuedAt.plus(ttl)))
             .signWith(secretKey)
             .compact();
     }
 
-    public String createJwt(String category, String username, String role, Long expiredMs) {
-        return createJwt(category, username, username, role, expiredMs);
+    public String createJwt(String category, String username, String role, Duration ttl) {
+        return createJwt(category, username, username, role, ttl);
     }
 
     public String extractUsernameFromExpiredToken(String token) {
@@ -72,6 +82,13 @@ public class JwtUtil {
                 .get("username", String.class);
         } catch (ExpiredJwtException e) {
             return e.getClaims().get("username", String.class);
+        }
+    }
+
+    private void requirePositiveTtl(Duration ttl) {
+        Objects.requireNonNull(ttl, "ttl must not be null");
+        if (ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("ttl must be positive");
         }
     }
 }

--- a/src/main/java/com/lshzzz/mato/utils/users/filter/JwtFilter.java
+++ b/src/main/java/com/lshzzz/mato/utils/users/filter/JwtFilter.java
@@ -2,6 +2,7 @@ package com.lshzzz.mato.utils.users.filter;
 
 import com.lshzzz.mato.model.users.CustomUserDetails;
 import com.lshzzz.mato.service.users.RefreshTokenService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
 import com.lshzzz.mato.utils.users.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -54,26 +55,33 @@ public class JwtFilter extends OncePerRequestFilter {
 
                     if (storedRefreshToken != null
                         && !jwtUtil.isExpired(storedRefreshToken)
-                        && Objects.equals("refresh", jwtUtil.getCategory(storedRefreshToken))) {
+                        && Objects.equals(
+                            AuthTokenPolicy.REFRESH_CATEGORY,
+                            jwtUtil.getCategory(storedRefreshToken)
+                        )) {
                         String role = jwtUtil.getRole(storedRefreshToken);
                         String nickname = resolveNickname(storedRefreshToken, username);
                         String newAccessToken = jwtUtil.createJwt(
-                            "access",
+                            AuthTokenPolicy.ACCESS_CATEGORY,
                             username,
                             nickname,
                             role,
-                            600000L
+                            AuthTokenPolicy.ACCESS_TOKEN_TTL
                         );
                         String newRefreshToken = jwtUtil.createJwt(
-                            "refresh",
+                            AuthTokenPolicy.REFRESH_CATEGORY,
                             username,
                             nickname,
                             role,
-                            86400000L
+                            AuthTokenPolicy.REFRESH_TOKEN_TTL
                         );
 
                         refreshTokenService.deleteRefreshToken(username);
-                        refreshTokenService.saveRefreshToken(username, newRefreshToken, 86400L);
+                        refreshTokenService.saveRefreshToken(
+                            username,
+                            newRefreshToken,
+                            AuthTokenPolicy.REFRESH_TOKEN_TTL
+                        );
                         response.setHeader("Authorization", "Bearer " + newAccessToken);
                         setAuthentication(newAccessToken, request);
                     } else {

--- a/src/main/java/com/lshzzz/mato/utils/users/filter/LoginFilter.java
+++ b/src/main/java/com/lshzzz/mato/utils/users/filter/LoginFilter.java
@@ -2,6 +2,7 @@ package com.lshzzz.mato.utils.users.filter;
 
 import com.lshzzz.mato.model.users.CustomUserDetails;
 import com.lshzzz.mato.service.users.RefreshTokenService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
 import com.lshzzz.mato.utils.users.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,21 +45,25 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         HttpServletResponse response, FilterChain chain, Authentication authentication) {
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         String access = jwtUtil.createJwt(
-            "access",
+            AuthTokenPolicy.ACCESS_CATEGORY,
             customUserDetails.getUsername(),
             customUserDetails.getNickname(),
             customUserDetails.getAuthorities().iterator().next().getAuthority(),
-            600000L
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
         );
         String refresh = jwtUtil.createJwt(
-            "refresh",
+            AuthTokenPolicy.REFRESH_CATEGORY,
             customUserDetails.getUsername(),
             customUserDetails.getNickname(),
             customUserDetails.getAuthorities().iterator().next().getAuthority(),
-            86400000L
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
         );
 
-        refreshTokenService.saveRefreshToken(customUserDetails.getUsername(), refresh, 86400L);
+        refreshTokenService.saveRefreshToken(
+            customUserDetails.getUsername(),
+            refresh,
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
 
         response.setHeader("Authorization", "Bearer " + access);
         response.setStatus(HttpStatus.OK.value());

--- a/src/test/java/com/lshzzz/mato/controller/users/UsersControllerTest.java
+++ b/src/test/java/com/lshzzz/mato/controller/users/UsersControllerTest.java
@@ -1,0 +1,64 @@
+package com.lshzzz.mato.controller.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lshzzz.mato.model.users.Role;
+import com.lshzzz.mato.model.users.dto.UsersLoginRequest;
+import com.lshzzz.mato.model.users.dto.UsersLoginResponse;
+import com.lshzzz.mato.service.users.RefreshTokenService;
+import com.lshzzz.mato.service.users.UsersService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
+import com.lshzzz.mato.utils.users.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class UsersControllerTest {
+
+    @Test
+    void apiLoginUsesSharedTokenLifetimes() {
+        UsersService usersService = mock(UsersService.class);
+        JwtUtil jwtUtil = mock(JwtUtil.class);
+        RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+        UsersController controller = new UsersController(
+            usersService,
+            jwtUtil,
+            refreshTokenService
+        );
+        UsersLoginRequest request = new UsersLoginRequest("user@example.com", "password");
+        UsersLoginResponse loginResponse = new UsersLoginResponse(
+            1L,
+            "user@example.com",
+            "nickname",
+            Role.USER
+        );
+        when(usersService.login(request.userId(), request.password())).thenReturn(loginResponse);
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.ACCESS_CATEGORY,
+            loginResponse.userId(),
+            loginResponse.nickname(),
+            loginResponse.role().name(),
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
+        )).thenReturn("access-token");
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.REFRESH_CATEGORY,
+            loginResponse.userId(),
+            loginResponse.nickname(),
+            loginResponse.role().name(),
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        )).thenReturn("refresh-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        var result = controller.login(request, response);
+
+        verify(refreshTokenService).saveRefreshToken(
+            loginResponse.userId(),
+            "refresh-token",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+        assertThat(response.getHeader("Authorization")).isEqualTo("Bearer access-token");
+        assertThat(result.getBody()).isEqualTo(loginResponse);
+    }
+}

--- a/src/test/java/com/lshzzz/mato/service/users/RefreshTokenServiceTest.java
+++ b/src/test/java/com/lshzzz/mato/service/users/RefreshTokenServiceTest.java
@@ -1,0 +1,98 @@
+package com.lshzzz.mato.service.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class RefreshTokenServiceTest {
+
+    @Test
+    void storesRefreshTokenWithThirtyDayRedisTtl() {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        RefreshTokenService service = new RefreshTokenService(redisTemplate);
+
+        service.saveRefreshToken(
+            "user@example.com",
+            "refresh-token",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+
+        verify(valueOperations).set(
+            "refresh:user@example.com",
+            "refresh-token",
+            Duration.ofDays(30)
+        );
+    }
+
+    @Test
+    void redisFallbackExpiresAtTheSameThirtyDayBoundary() {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        doThrow(new IllegalStateException("redis unavailable"))
+            .when(valueOperations)
+            .set(
+                "refresh:user@example.com",
+                "refresh-token",
+                AuthTokenPolicy.REFRESH_TOKEN_TTL
+            );
+        when(valueOperations.get("refresh:user@example.com"))
+            .thenThrow(new IllegalStateException("redis unavailable"));
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-07T00:00:00Z"));
+        RefreshTokenService service = new RefreshTokenService(redisTemplate, clock);
+
+        service.saveRefreshToken(
+            "user@example.com",
+            "refresh-token",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+        clock.advance(Duration.ofDays(30).minusSeconds(1));
+        assertThat(service.getRefreshToken("user@example.com")).isEqualTo("refresh-token");
+
+        clock.advance(Duration.ofSeconds(1));
+        assertThat(service.getRefreshToken("user@example.com")).isNull();
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private Instant current;
+
+        private MutableClock(Instant current) {
+            this.current = current;
+        }
+
+        private void advance(Duration duration) {
+            current = current.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return current;
+        }
+    }
+}

--- a/src/test/java/com/lshzzz/mato/utils/users/AuthTokenPolicyTest.java
+++ b/src/test/java/com/lshzzz/mato/utils/users/AuthTokenPolicyTest.java
@@ -1,0 +1,94 @@
+package com.lshzzz.mato.utils.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenPolicyTest {
+
+    private static final String SECRET = "test-secret-key-test-secret-key-1234";
+
+    @Test
+    void keepsAccessAtTenMinutesAndRefreshAtThirtyDays() {
+        assertThat(AuthTokenPolicy.ACCESS_TOKEN_TTL).isEqualTo(Duration.ofMinutes(10));
+        assertThat(AuthTokenPolicy.REFRESH_TOKEN_TTL).isEqualTo(Duration.ofDays(30));
+    }
+
+    @Test
+    void jwtExpirationUsesThePolicyDuration() {
+        JwtUtil jwtUtil = new JwtUtil(SECRET);
+
+        String accessToken = jwtUtil.createJwt(
+            AuthTokenPolicy.ACCESS_CATEGORY,
+            "user@example.com",
+            "nickname",
+            "ROLE_USER",
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
+        );
+        String refreshToken = jwtUtil.createJwt(
+            AuthTokenPolicy.REFRESH_CATEGORY,
+            "user@example.com",
+            "nickname",
+            "ROLE_USER",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+
+        assertThat(tokenLifetime(accessToken)).isEqualTo(AuthTokenPolicy.ACCESS_TOKEN_TTL);
+        assertThat(tokenLifetime(refreshToken)).isEqualTo(AuthTokenPolicy.REFRESH_TOKEN_TTL);
+    }
+
+    @Test
+    void rejectsNonPositiveTokenLifetime() {
+        JwtUtil jwtUtil = new JwtUtil(SECRET);
+
+        assertThatThrownBy(() -> jwtUtil.createJwt(
+            AuthTokenPolicy.ACCESS_CATEGORY,
+            "user@example.com",
+            "ROLE_USER",
+            Duration.ZERO
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void identifiesExpiredJwtWithoutPropagatingParserException() {
+        JwtUtil jwtUtil = new JwtUtil(SECRET);
+        Instant now = Instant.now();
+        String expiredToken = Jwts.builder()
+            .claim("category", AuthTokenPolicy.REFRESH_CATEGORY)
+            .claim("username", "user@example.com")
+            .issuedAt(Date.from(now.minus(Duration.ofMinutes(2))))
+            .expiration(Date.from(now.minus(Duration.ofMinutes(1))))
+            .signWith(secretKey())
+            .compact();
+
+        assertThat(jwtUtil.isExpired(expiredToken)).isTrue();
+    }
+
+    private Duration tokenLifetime(String token) {
+        var claims = Jwts.parser()
+            .verifyWith(secretKey())
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        return Duration.between(
+            claims.getIssuedAt().toInstant(),
+            claims.getExpiration().toInstant()
+        );
+    }
+
+    private SecretKey secretKey() {
+        return new SecretKeySpec(
+            SECRET.getBytes(StandardCharsets.UTF_8),
+            Jwts.SIG.HS256.key().build().getAlgorithm()
+        );
+    }
+}

--- a/src/test/java/com/lshzzz/mato/utils/users/filter/JwtFilterTest.java
+++ b/src/test/java/com/lshzzz/mato/utils/users/filter/JwtFilterTest.java
@@ -1,0 +1,77 @@
+package com.lshzzz.mato.utils.users.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lshzzz.mato.service.users.RefreshTokenService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
+import com.lshzzz.mato.utils.users.JwtUtil;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class JwtFilterTest {
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void expiredAccessSlidesRefreshSessionByThirtyDays() throws Exception {
+        JwtUtil jwtUtil = mock(JwtUtil.class);
+        RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+        FilterChain filterChain = mock(FilterChain.class);
+        JwtFilter filter = new JwtFilter(jwtUtil, refreshTokenService);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Authorization", "Bearer expired-access");
+
+        when(jwtUtil.getUsername("expired-access"))
+            .thenThrow(new IllegalStateException("expired"));
+        when(jwtUtil.extractUsernameFromExpiredToken("expired-access"))
+            .thenReturn("user@example.com");
+        when(refreshTokenService.getRefreshToken("user@example.com"))
+            .thenReturn("stored-refresh");
+        when(jwtUtil.isExpired("stored-refresh")).thenReturn(false);
+        when(jwtUtil.getCategory("stored-refresh"))
+            .thenReturn(AuthTokenPolicy.REFRESH_CATEGORY);
+        when(jwtUtil.getRole("stored-refresh")).thenReturn("ROLE_USER");
+        when(jwtUtil.getNickname("stored-refresh")).thenReturn("nickname");
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.ACCESS_CATEGORY,
+            "user@example.com",
+            "nickname",
+            "ROLE_USER",
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
+        )).thenReturn("new-access");
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.REFRESH_CATEGORY,
+            "user@example.com",
+            "nickname",
+            "ROLE_USER",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        )).thenReturn("new-refresh");
+        when(jwtUtil.getUsername("new-access")).thenReturn("user@example.com");
+        when(jwtUtil.getRole("new-access")).thenReturn("ROLE_USER");
+        when(jwtUtil.getNickname("new-access")).thenReturn("nickname");
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(refreshTokenService).deleteRefreshToken("user@example.com");
+        verify(refreshTokenService).saveRefreshToken(
+            "user@example.com",
+            "new-refresh",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+        verify(filterChain).doFilter(request, response);
+        assertThat(response.getHeader("Authorization")).isEqualTo("Bearer new-access");
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+            .isEqualTo("user@example.com");
+    }
+}

--- a/src/test/java/com/lshzzz/mato/utils/users/filter/LoginFilterTest.java
+++ b/src/test/java/com/lshzzz/mato/utils/users/filter/LoginFilterTest.java
@@ -1,0 +1,69 @@
+package com.lshzzz.mato.utils.users.filter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lshzzz.mato.model.users.CustomUserDetails;
+import com.lshzzz.mato.service.users.RefreshTokenService;
+import com.lshzzz.mato.utils.users.AuthTokenPolicy;
+import com.lshzzz.mato.utils.users.JwtUtil;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class LoginFilterTest {
+
+    @Test
+    void loginUsesSharedTokenLifetimes() {
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        JwtUtil jwtUtil = mock(JwtUtil.class);
+        RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+        Authentication authentication = mock(Authentication.class);
+        CustomUserDetails user = new CustomUserDetails(
+            "user@example.com",
+            "nickname",
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        when(authentication.getPrincipal()).thenReturn(user);
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.ACCESS_CATEGORY,
+            user.getUsername(),
+            user.getNickname(),
+            "ROLE_USER",
+            AuthTokenPolicy.ACCESS_TOKEN_TTL
+        )).thenReturn("access-token");
+        when(jwtUtil.createJwt(
+            AuthTokenPolicy.REFRESH_CATEGORY,
+            user.getUsername(),
+            user.getNickname(),
+            "ROLE_USER",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        )).thenReturn("refresh-token");
+        LoginFilter filter = new LoginFilter(
+            authenticationManager,
+            jwtUtil,
+            refreshTokenService
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.successfulAuthentication(
+            new MockHttpServletRequest(),
+            response,
+            mock(jakarta.servlet.FilterChain.class),
+            authentication
+        );
+
+        verify(refreshTokenService).saveRefreshToken(
+            user.getUsername(),
+            "refresh-token",
+            AuthTokenPolicy.REFRESH_TOKEN_TTL
+        );
+        org.assertj.core.api.Assertions.assertThat(response.getHeader("Authorization"))
+            .isEqualTo("Bearer access-token");
+    }
+}


### PR DESCRIPTION
## 변경 내용
- access token 10분 정책은 유지하고 refresh session을 24시간에서 30일로 연장합니다.
- 로그인과 만료 access 갱신 경로가 공통 `AuthTokenPolicy`를 사용하도록 통일합니다.
- access token 갱신 시 refresh JWT와 Redis TTL도 30일로 재설정해 sliding session으로 동작합니다.
- Redis 장애 fallback에도 동일한 만료 경계를 적용하고, 만료 JWT 판별이 예외 대신 `true`를 반환하도록 보강합니다.
- 컨트롤러·로그인 필터·JWT 갱신·Redis TTL 정책 테스트를 추가합니다.

## 원인
refresh token과 Redis TTL이 24시간으로 하드코딩돼 하루 이상 재접속하지 않으면 세션 복원이 실패했습니다.

## 검증
- 관련 인증 정책 테스트 5개 클래스, 총 9개 테스트 통과
- 전체 소스 및 테스트 컴파일 통과
- `git diff --check`